### PR TITLE
feat(infra): setup shared tooling configs (#32)

### DIFF
--- a/.pair/adoption/decision-log/2026-05-21-verbatim-from-pair-tooling.md
+++ b/.pair/adoption/decision-log/2026-05-21-verbatim-from-pair-tooling.md
@@ -1,0 +1,54 @@
+# ADL — Verbatim-from-pair as Source of Truth for `tools/*`
+
+**Date:** 2026-05-21
+**Status:** Accepted
+**Type:** Non-architectural (ADL)
+**Scope:** `tools/eslint-config`, `tools/prettier-config`, `tools/markdownlint-config`, `tools/ts-config`
+
+## Context
+
+`foomakers/pair` is the reference monorepo gilberto bootstraps from. Its `tools/*` packages already encode lint/format/typecheck conventions that have been battle-tested across pair workspaces. Re-deriving each preset risks drift and bikeshedding.
+
+## Decision
+
+`tools/*` configuration is **verbatim-copied** from `foomakers/pair/tools/*`, with the single mechanical adaptation of renaming the npm scope `@pair/` → `@gilberto/`. The pair source remains canonical: when pair updates a preset, gilberto pulls the change rather than diverging.
+
+### Permitted deviations from verbatim
+
+- **Namespace rename** (`@pair/*` → `@gilberto/*`) — required to publish in the gilberto org.
+- **Language of in-code comments** — pair has Italian comments; gilberto enforces English-only artifacts (per memory + CLAUDE.md). Translation is required, not a deviation.
+- **Documentation references** (READMEs, comments naming the project) — gilberto-specific text replaces pair-specific text.
+- **Files unused under ESLint 9 flat-config** (e.g. `.eslintignore`) — may be dropped if functionally dead.
+
+### Explicit deviation from story AC: `eslint-config-prettier` omitted
+
+Story #32 §Edge Cases and §T-3 dependencies prescribe `eslint-config-prettier` to disable ESLint formatting rules conflicting with Prettier. Pair's `eslint.config.cjs` does not use it. Verbatim-from-pair wins.
+
+Safety verification (2026-05-21): `grep -E "prefer-arrow|indent|quotes|semi|comma|space" tools/eslint-config/eslint.config.cjs` returns no matches. Pair's rule set is purely code-quality (`complexity`, `max-depth`, `max-lines-per-function`, `max-params`, `@typescript-eslint/no-explicit-any`, `prefer-const`, `no-var`, `no-throw-literal`) plus the `@typescript-eslint/recommended` and `eslint:recommended` rule packs. None of these enable stylistic rules that Prettier would override. Conflict surface = empty.
+
+## Consequences
+
+### Positive
+
+- Zero drift between pair and gilberto for shared tooling.
+- Updates propagate by `cp` from pair, not by re-design.
+- Story AC-7's "self-validate" check can be expressed as a script in each `tools/*/package.json` referencing only the verbatim files.
+
+### Negative
+
+- Story AC-7 cannot be read literally: pair's `tools/*` do not ship `ts:check` scripts of the exact form the story specified. Mitigated by adding minimal `ts:check` scripts that load each config and assert it parses, without modifying the verbatim config content.
+- Story §Edge Cases #2 (eslint-config-prettier) is overridden by this ADL. Any future ESLint rule additions that introduce stylistic rules must re-validate the conflict surface and reconsider `eslint-config-prettier`.
+- Italian comments in pair's `eslint.config.cjs` must be translated. The translation is a one-time cost and not propagated back upstream.
+
+## When to revisit
+
+- Pair adds `eslint-config-prettier` (re-sync).
+- Pair adds stylistic ESLint rules (re-validate conflict surface; consider adding `eslint-config-prettier` regardless of pair).
+- gilberto needs a rule pair doesn't have (then the decision shifts from verbatim-from-pair to deliberate divergence per-rule).
+
+## References
+
+- Story: rucka/gilberto#32
+- PR: rucka/gilberto#50
+- Pair source: `foomakers/pair/tools/{eslint-config,prettier-config,markdownlint-config,ts-config}/`
+- Guidelines re: eslint-config-prettier: `.pair/knowledge/guidelines/code-design/quality-standards/eslint.md` §Conflicting Rules; `.pair/knowledge/guidelines/code-design/quality-standards/prettier-formatting.md` §Conflict Resolution

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6,9 +6,30 @@ settings:
 
 catalogs:
   default:
+    '@eslint/js':
+      specifier: 9.34.0
+      version: 9.34.0
     '@foomakers/pair-cli':
       specifier: ^0.4.3
       version: 0.4.3
+    '@typescript-eslint/eslint-plugin':
+      specifier: 8.41.0
+      version: 8.41.0
+    '@typescript-eslint/parser':
+      specifier: 8.41.0
+      version: 8.41.0
+    eslint:
+      specifier: 9.34.0
+      version: 9.34.0
+    globals:
+      specifier: 15.0.0
+      version: 15.0.0
+    markdownlint-cli:
+      specifier: 0.47.0
+      version: 0.47.0
+    prettier:
+      specifier: 3.6.2
+      version: 3.6.2
     turbo:
       specifier: ^2.3.3
       version: 2.9.14
@@ -24,11 +45,113 @@ importers:
         specifier: 'catalog:'
         version: 2.9.14
 
+  tools/eslint-config:
+    devDependencies:
+      '@eslint/js':
+        specifier: 'catalog:'
+        version: 9.34.0
+      '@typescript-eslint/eslint-plugin':
+        specifier: 'catalog:'
+        version: 8.41.0(@typescript-eslint/parser@8.41.0(eslint@9.34.0)(typescript@5.9.3))(eslint@9.34.0)(typescript@5.9.3)
+      '@typescript-eslint/parser':
+        specifier: 'catalog:'
+        version: 8.41.0(eslint@9.34.0)(typescript@5.9.3)
+      eslint:
+        specifier: 'catalog:'
+        version: 9.34.0
+      globals:
+        specifier: 'catalog:'
+        version: 15.0.0
+
+  tools/markdownlint-config:
+    devDependencies:
+      markdownlint-cli:
+        specifier: 'catalog:'
+        version: 0.47.0
+
+  tools/prettier-config:
+    devDependencies:
+      prettier:
+        specifier: 'catalog:'
+        version: 3.6.2
+
+  tools/ts-config: {}
+
 packages:
+
+  '@eslint-community/eslint-utils@4.9.1':
+    resolution: {integrity: sha512-phrYmNiYppR7znFEdqgfWHXR6NCkZEK7hwWDHZUjit/2/U0r6XvkDl0SYnoM51Hq7FhCGdLDT6zxCCOY1hexsQ==}
+    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
+    peerDependencies:
+      eslint: ^6.0.0 || ^7.0.0 || >=8.0.0
+
+  '@eslint-community/regexpp@4.12.2':
+    resolution: {integrity: sha512-EriSTlt5OC9/7SXkRSCAhfSxxoSUgBm33OH+IkwbdpgoqsSsUg7y3uh+IICI/Qg4BBWr3U2i39RpmycbxMq4ew==}
+    engines: {node: ^12.0.0 || ^14.0.0 || >=16.0.0}
+
+  '@eslint/config-array@0.21.2':
+    resolution: {integrity: sha512-nJl2KGTlrf9GjLimgIru+V/mzgSK0ABCDQRvxw5BjURL7WfH5uoWmizbH7QB6MmnMBd8cIC9uceWnezL1VZWWw==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
+  '@eslint/config-helpers@0.3.1':
+    resolution: {integrity: sha512-xR93k9WhrDYpXHORXpxVL5oHj3Era7wo6k/Wd8/IsQNnZUTzkGS29lyn3nAT05v6ltUuTFVCCYDEGfy2Or/sPA==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
+  '@eslint/core@0.15.2':
+    resolution: {integrity: sha512-78Md3/Rrxh83gCxoUc0EiciuOHsIITzLy53m3d9UyiW8y9Dj2D29FeETqyKA+BRK76tnTp6RXWb3pCay8Oyomg==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
+  '@eslint/eslintrc@3.3.5':
+    resolution: {integrity: sha512-4IlJx0X0qftVsN5E+/vGujTRIFtwuLbNsVUe7TO6zYPDR1O6nFwvwhIKEKSrl6dZchmYBITazxKoUYOjdtjlRg==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
+  '@eslint/js@9.34.0':
+    resolution: {integrity: sha512-EoyvqQnBNsV1CWaEJ559rxXL4c8V92gxirbawSmVUOWXlsRxxQXl6LmCpdUblgxgSkDIqKnhzba2SjRTI/A5Rw==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
+  '@eslint/object-schema@2.1.7':
+    resolution: {integrity: sha512-VtAOaymWVfZcmZbp6E2mympDIHvyjXs/12LqWYjVw6qjrfF+VK+fyG33kChz3nnK+SU5/NeHOqrTEHS8sXO3OA==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
+  '@eslint/plugin-kit@0.3.5':
+    resolution: {integrity: sha512-Z5kJ+wU3oA7MMIqVR9tyZRtjYPr4OC004Q4Rw7pgOKUOKkJfZ3O24nz3WYfGRpMDNmcOi3TwQOmgm7B7Tpii0w==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
   '@foomakers/pair-cli@0.4.3':
     resolution: {integrity: sha512-gCe2L99TWYolsQfYczd8zeBk6MSq8qm1lN7M+h7wLPlzjqmPkDIUhAukPzhZDQTG/xvziPdNX9PXcdicD/rIeg==}
     hasBin: true
+
+  '@humanfs/core@0.19.2':
+    resolution: {integrity: sha512-UhXNm+CFMWcbChXywFwkmhqjs3PRCmcSa/hfBgLIb7oQ5HNb1wS0icWsGtSAUNgefHeI+eBrA8I1fxmbHsGdvA==}
+    engines: {node: '>=18.18.0'}
+
+  '@humanfs/node@0.16.8':
+    resolution: {integrity: sha512-gE1eQNZ3R++kTzFUpdGlpmy8kDZD/MLyHqDwqjkVQI0JMdI1D51sy1H958PNXYkM2rAac7e5/CnIKZrHtPh3BQ==}
+    engines: {node: '>=18.18.0'}
+
+  '@humanfs/types@0.15.0':
+    resolution: {integrity: sha512-ZZ1w0aoQkwuUuC7Yf+7sdeaNfqQiiLcSRbfI08oAxqLtpXQr9AIVX7Ay7HLDuiLYAaFPu8oBYNq/QIi9URHJ3Q==}
+    engines: {node: '>=18.18.0'}
+
+  '@humanwhocodes/module-importer@1.0.1':
+    resolution: {integrity: sha512-bxveV4V8v5Yb4ncFTT3rPSgZBOpCkjfK0y4oVVVJwIuDVBRMDXrPyXRL988i5ap9m9bnyEEjWfm5WkBmtffLfA==}
+    engines: {node: '>=12.22'}
+
+  '@humanwhocodes/retry@0.4.3':
+    resolution: {integrity: sha512-bV0Tgo9K4hfPCek+aMAn81RppFKv2ySDQeMoSZuvTASywNTnVJCArCZE2FWqpvIatKu7VMRLWlR1EazvVhDyhQ==}
+    engines: {node: '>=18.18'}
+
+  '@nodelib/fs.scandir@2.1.5':
+    resolution: {integrity: sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==}
+    engines: {node: '>= 8'}
+
+  '@nodelib/fs.stat@2.0.5':
+    resolution: {integrity: sha512-RkhPPp2zrqDAQA/2jNhnztcPAlv64XdhIp7a7454A5ovI7Bukxgt7MX7udwAu3zg1DcpPU0rz3VV1SeaqvY4+A==}
+    engines: {node: '>= 8'}
+
+  '@nodelib/fs.walk@1.2.8':
+    resolution: {integrity: sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==}
+    engines: {node: '>= 8'}
 
   '@turbo/darwin-64@2.9.14':
     resolution: {integrity: sha512-t7QiPflaEyBE4oayeZtSmu4mEfjgIrcNlNNl1z1dmIVPqEdtA7+CfTf8d7KXsOGPh6aNgWjKxyvQg9uGfDQF+A==}
@@ -60,13 +183,745 @@ packages:
     cpu: [arm64]
     os: [win32]
 
+  '@types/debug@4.1.13':
+    resolution: {integrity: sha512-KSVgmQmzMwPlmtljOomayoR89W4FynCAi3E8PPs7vmDVPe84hT+vGPKkJfThkmXs0x0jAaa9U8uW8bbfyS2fWw==}
+
+  '@types/estree@1.0.9':
+    resolution: {integrity: sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==}
+
+  '@types/json-schema@7.0.15':
+    resolution: {integrity: sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==}
+
+  '@types/katex@0.16.8':
+    resolution: {integrity: sha512-trgaNyfU+Xh2Tc+ABIb44a5AYUpicB3uwirOioeOkNPPbmgRNtcWyDeeFRzjPZENO9Vq8gvVqfhaaXWLlevVwg==}
+
+  '@types/ms@2.1.0':
+    resolution: {integrity: sha512-GsCCIZDE/p3i96vtEqx+7dBUGXrc7zeSK3wwPHIaRThS+9OhWIXRqzs4d6k1SVU8g91DrNRWxWUGhp5KXQb2VA==}
+
+  '@types/unist@2.0.11':
+    resolution: {integrity: sha512-CmBKiL6NNo/OqgmMn95Fk9Whlp2mtvIv+KNpQKN2F4SjvrEesubTRWGYSg+BnWZOnlCaSTU1sMpsBOzgbYhnsA==}
+
+  '@typescript-eslint/eslint-plugin@8.41.0':
+    resolution: {integrity: sha512-8fz6oa6wEKZrhXWro/S3n2eRJqlRcIa6SlDh59FXJ5Wp5XRZ8B9ixpJDcjadHq47hMx0u+HW6SNa6LjJQ6NLtw==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    peerDependencies:
+      '@typescript-eslint/parser': ^8.41.0
+      eslint: ^8.57.0 || ^9.0.0
+      typescript: '>=4.8.4 <6.0.0'
+
+  '@typescript-eslint/parser@8.41.0':
+    resolution: {integrity: sha512-gTtSdWX9xiMPA/7MV9STjJOOYtWwIJIYxkQxnSV1U3xcE+mnJSH3f6zI0RYP+ew66WSlZ5ed+h0VCxsvdC1jJg==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    peerDependencies:
+      eslint: ^8.57.0 || ^9.0.0
+      typescript: '>=4.8.4 <6.0.0'
+
+  '@typescript-eslint/project-service@8.41.0':
+    resolution: {integrity: sha512-b8V9SdGBQzQdjJ/IO3eDifGpDBJfvrNTp2QD9P2BeqWTGrRibgfgIlBSw6z3b6R7dPzg752tOs4u/7yCLxksSQ==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    peerDependencies:
+      typescript: '>=4.8.4 <6.0.0'
+
+  '@typescript-eslint/scope-manager@8.41.0':
+    resolution: {integrity: sha512-n6m05bXn/Cd6DZDGyrpXrELCPVaTnLdPToyhBoFkLIMznRUQUEQdSp96s/pcWSQdqOhrgR1mzJ+yItK7T+WPMQ==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
+  '@typescript-eslint/tsconfig-utils@8.41.0':
+    resolution: {integrity: sha512-TDhxYFPUYRFxFhuU5hTIJk+auzM/wKvWgoNYOPcOf6i4ReYlOoYN8q1dV5kOTjNQNJgzWN3TUUQMtlLOcUgdUw==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    peerDependencies:
+      typescript: '>=4.8.4 <6.0.0'
+
+  '@typescript-eslint/type-utils@8.41.0':
+    resolution: {integrity: sha512-63qt1h91vg3KsjVVonFJWjgSK7pZHSQFKH6uwqxAH9bBrsyRhO6ONoKyXxyVBzG1lJnFAJcKAcxLS54N1ee1OQ==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    peerDependencies:
+      eslint: ^8.57.0 || ^9.0.0
+      typescript: '>=4.8.4 <6.0.0'
+
+  '@typescript-eslint/types@8.41.0':
+    resolution: {integrity: sha512-9EwxsWdVqh42afLbHP90n2VdHaWU/oWgbH2P0CfcNfdKL7CuKpwMQGjwev56vWu9cSKU7FWSu6r9zck6CVfnag==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
+  '@typescript-eslint/typescript-estree@8.41.0':
+    resolution: {integrity: sha512-D43UwUYJmGhuwHfY7MtNKRZMmfd8+p/eNSfFe6tH5mbVDto+VQCayeAt35rOx3Cs6wxD16DQtIKw/YXxt5E0UQ==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    peerDependencies:
+      typescript: '>=4.8.4 <6.0.0'
+
+  '@typescript-eslint/utils@8.41.0':
+    resolution: {integrity: sha512-udbCVstxZ5jiPIXrdH+BZWnPatjlYwJuJkDA4Tbo3WyYLh8NvB+h/bKeSZHDOFKfphsZYJQqaFtLeXEqurQn1A==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    peerDependencies:
+      eslint: ^8.57.0 || ^9.0.0
+      typescript: '>=4.8.4 <6.0.0'
+
+  '@typescript-eslint/visitor-keys@8.41.0':
+    resolution: {integrity: sha512-+GeGMebMCy0elMNg67LRNoVnUFPIm37iu5CmHESVx56/9Jsfdpsvbv605DQ81Pi/x11IdKUsS5nzgTYbCQU9fg==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
+  acorn-jsx@5.3.2:
+    resolution: {integrity: sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==}
+    peerDependencies:
+      acorn: ^6.0.0 || ^7.0.0 || ^8.0.0
+
+  acorn@8.16.0:
+    resolution: {integrity: sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==}
+    engines: {node: '>=0.4.0'}
+    hasBin: true
+
+  ajv@6.15.0:
+    resolution: {integrity: sha512-fgFx7Hfoq60ytK2c7DhnF8jIvzYgOMxfugjLOSMHjLIPgenqa7S7oaagATUq99mV6IYvN2tRmC0wnTYX6iPbMw==}
+
+  ansi-regex@6.2.2:
+    resolution: {integrity: sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==}
+    engines: {node: '>=12'}
+
+  ansi-styles@4.3.0:
+    resolution: {integrity: sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==}
+    engines: {node: '>=8'}
+
+  argparse@2.0.1:
+    resolution: {integrity: sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==}
+
+  balanced-match@1.0.2:
+    resolution: {integrity: sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==}
+
+  balanced-match@4.0.4:
+    resolution: {integrity: sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==}
+    engines: {node: 18 || 20 || >=22}
+
+  brace-expansion@1.1.14:
+    resolution: {integrity: sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==}
+
+  brace-expansion@2.1.0:
+    resolution: {integrity: sha512-TN1kCZAgdgweJhWWpgKYrQaMNHcDULHkWwQIspdtjV4Y5aurRdZpjAqn6yX3FPqTA9ngHCc4hJxMAMgGfve85w==}
+
+  brace-expansion@5.0.6:
+    resolution: {integrity: sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==}
+    engines: {node: 18 || 20 || >=22}
+
+  braces@3.0.3:
+    resolution: {integrity: sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==}
+    engines: {node: '>=8'}
+
+  callsites@3.1.0:
+    resolution: {integrity: sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==}
+    engines: {node: '>=6'}
+
+  chalk@4.1.2:
+    resolution: {integrity: sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==}
+    engines: {node: '>=10'}
+
+  character-entities-legacy@3.0.0:
+    resolution: {integrity: sha512-RpPp0asT/6ufRm//AJVwpViZbGM/MkjQFxJccQRHmISF/22NBtsHqAWmL+/pmkPWoIUJdWyeVleTl1wydHATVQ==}
+
+  character-entities@2.0.2:
+    resolution: {integrity: sha512-shx7oQ0Awen/BRIdkjkvz54PnEEI/EjwXDSIZp86/KKdbafHh1Df/RYGBhn4hbe2+uKC9FnT5UCEdyPz3ai9hQ==}
+
+  character-reference-invalid@2.0.1:
+    resolution: {integrity: sha512-iBZ4F4wRbyORVsu0jPV7gXkOsGYjGHPmAyv+HiHG8gi5PtC9KI2j1+v8/tlibRvjoWX027ypmG/n0HtO5t7unw==}
+
+  color-convert@2.0.1:
+    resolution: {integrity: sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==}
+    engines: {node: '>=7.0.0'}
+
+  color-name@1.1.4:
+    resolution: {integrity: sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==}
+
+  commander@14.0.3:
+    resolution: {integrity: sha512-H+y0Jo/T1RZ9qPP4Eh1pkcQcLRglraJaSLoyOtHxu6AapkjWVCy2Sit1QQ4x3Dng8qDlSsZEet7g5Pq06MvTgw==}
+    engines: {node: '>=20'}
+
+  commander@8.3.0:
+    resolution: {integrity: sha512-OkTL9umf+He2DZkUq8f8J9of7yL6RJKI24dVITBmNfZBmri9zYZQrKkuXiKhyfPSu8tUhnVBB1iKXevvnlR4Ww==}
+    engines: {node: '>= 12'}
+
+  concat-map@0.0.1:
+    resolution: {integrity: sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==}
+
+  cross-spawn@7.0.6:
+    resolution: {integrity: sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==}
+    engines: {node: '>= 8'}
+
+  debug@4.4.3:
+    resolution: {integrity: sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==}
+    engines: {node: '>=6.0'}
+    peerDependencies:
+      supports-color: '*'
+    peerDependenciesMeta:
+      supports-color:
+        optional: true
+
+  decode-named-character-reference@1.3.0:
+    resolution: {integrity: sha512-GtpQYB283KrPp6nRw50q3U9/VfOutZOe103qlN7BPP6Ad27xYnOIWv4lPzo8HCAL+mMZofJ9KEy30fq6MfaK6Q==}
+
+  deep-extend@0.6.0:
+    resolution: {integrity: sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==}
+    engines: {node: '>=4.0.0'}
+
+  deep-is@0.1.4:
+    resolution: {integrity: sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==}
+
+  dequal@2.0.3:
+    resolution: {integrity: sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==}
+    engines: {node: '>=6'}
+
+  devlop@1.1.0:
+    resolution: {integrity: sha512-RWmIqhcFf1lRYBvNmr7qTNuyCt/7/ns2jbpp1+PalgE/rDQcBT0fioSMUpJ93irlUhC5hrg4cYqe6U+0ImW0rA==}
+
+  entities@4.5.0:
+    resolution: {integrity: sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==}
+    engines: {node: '>=0.12'}
+
+  escape-string-regexp@4.0.0:
+    resolution: {integrity: sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==}
+    engines: {node: '>=10'}
+
+  eslint-scope@8.4.0:
+    resolution: {integrity: sha512-sNXOfKCn74rt8RICKMvJS7XKV/Xk9kA7DyJr8mJik3S7Cwgy3qlkkmyS2uQB3jiJg6VNdZd/pDBJu0nvG2NlTg==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
+  eslint-visitor-keys@3.4.3:
+    resolution: {integrity: sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag==}
+    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
+
+  eslint-visitor-keys@4.2.1:
+    resolution: {integrity: sha512-Uhdk5sfqcee/9H/rCOJikYz67o0a2Tw2hGRPOG2Y1R2dg7brRe1uG0yaNQDHu+TO/uQPF/5eCapvYSmHUjt7JQ==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
+  eslint@9.34.0:
+    resolution: {integrity: sha512-RNCHRX5EwdrESy3Jc9o8ie8Bog+PeYvvSR8sDGoZxNFTvZ4dlxUB3WzQ3bQMztFrSRODGrLLj8g6OFuGY/aiQg==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    hasBin: true
+    peerDependencies:
+      jiti: '*'
+    peerDependenciesMeta:
+      jiti:
+        optional: true
+
+  espree@10.4.0:
+    resolution: {integrity: sha512-j6PAQ2uUr79PZhBjP5C5fhl8e39FmRnOjsD5lGnWrFU8i2G776tBK7+nP8KuQUTTyAZUwfQqXAgrVH5MbH9CYQ==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
+  esquery@1.7.0:
+    resolution: {integrity: sha512-Ap6G0WQwcU/LHsvLwON1fAQX9Zp0A2Y6Y/cJBl9r/JbW90Zyg4/zbG6zzKa2OTALELarYHmKu0GhpM5EO+7T0g==}
+    engines: {node: '>=0.10'}
+
+  esrecurse@4.3.0:
+    resolution: {integrity: sha512-KmfKL3b6G+RXvP8N1vr3Tq1kL/oCFgn2NYXEtqP8/L3pKapUA4G8cFVaoF3SU323CD4XypR/ffioHmkti6/Tag==}
+    engines: {node: '>=4.0'}
+
+  estraverse@5.3.0:
+    resolution: {integrity: sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==}
+    engines: {node: '>=4.0'}
+
+  esutils@2.0.3:
+    resolution: {integrity: sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==}
+    engines: {node: '>=0.10.0'}
+
+  fast-deep-equal@3.1.3:
+    resolution: {integrity: sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==}
+
+  fast-glob@3.3.3:
+    resolution: {integrity: sha512-7MptL8U0cqcFdzIzwOTHoilX9x5BrNqye7Z/LuC7kCMRio1EMSyqRK3BEAUD7sXRq4iT4AzTVuZdhgQ2TCvYLg==}
+    engines: {node: '>=8.6.0'}
+
+  fast-json-stable-stringify@2.1.0:
+    resolution: {integrity: sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==}
+
+  fast-levenshtein@2.0.6:
+    resolution: {integrity: sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==}
+
+  fastq@1.20.1:
+    resolution: {integrity: sha512-GGToxJ/w1x32s/D2EKND7kTil4n8OVk/9mycTc4VDza13lOvpUZTGX3mFSCtV9ksdGBVzvsyAVLM6mHFThxXxw==}
+
+  fdir@6.5.0:
+    resolution: {integrity: sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==}
+    engines: {node: '>=12.0.0'}
+    peerDependencies:
+      picomatch: ^3 || ^4
+    peerDependenciesMeta:
+      picomatch:
+        optional: true
+
+  file-entry-cache@8.0.0:
+    resolution: {integrity: sha512-XXTUwCvisa5oacNGRP9SfNtYBNAMi+RPwBFmblZEF7N7swHYQS6/Zfk7SRwx4D5j3CH211YNRco1DEMNVfZCnQ==}
+    engines: {node: '>=16.0.0'}
+
+  fill-range@7.1.1:
+    resolution: {integrity: sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==}
+    engines: {node: '>=8'}
+
+  find-up@5.0.0:
+    resolution: {integrity: sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==}
+    engines: {node: '>=10'}
+
+  flat-cache@4.0.1:
+    resolution: {integrity: sha512-f7ccFPK3SXFHpx15UIGyRJ/FJQctuKZ0zVuN3frBo4HnK3cay9VEW0R6yPYFHC0AgqhukPzKjq22t5DmAyqGyw==}
+    engines: {node: '>=16'}
+
+  flatted@3.4.2:
+    resolution: {integrity: sha512-PjDse7RzhcPkIJwy5t7KPWQSZ9cAbzQXcafsetQoD7sOJRQlGikNbx7yZp2OotDnJyrDcbyRq3Ttb18iYOqkxA==}
+
+  get-east-asian-width@1.6.0:
+    resolution: {integrity: sha512-QRbvDIbx6YklUe6RxeTeleMR0yv3cYH6PsPZHcnVn7xv7zO1BHN8r0XETu8n6Ye3Q+ahtSarc3WgtNWmehIBfA==}
+    engines: {node: '>=18'}
+
+  glob-parent@5.1.2:
+    resolution: {integrity: sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==}
+    engines: {node: '>= 6'}
+
+  glob-parent@6.0.2:
+    resolution: {integrity: sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==}
+    engines: {node: '>=10.13.0'}
+
+  globals@14.0.0:
+    resolution: {integrity: sha512-oahGvuMGQlPw/ivIYBjVSrWAfWLBeku5tpPE2fOPLi+WHffIWbuh2tCjhyQhTBPMf5E9jDEH4FOmTYgYwbKwtQ==}
+    engines: {node: '>=18'}
+
+  globals@15.0.0:
+    resolution: {integrity: sha512-m/C/yR4mjO6pXDTm9/R/SpYTAIyaUB4EOzcaaMEl7mds7Mshct9GfejiJNQGjHHbdMPey13Kpu4TMbYi9ex1pw==}
+    engines: {node: '>=18'}
+
+  graphemer@1.4.0:
+    resolution: {integrity: sha512-EtKwoO6kxCL9WO5xipiHTZlSzBm7WLT627TqC/uVRd0HKmq8NXyebnNYxDoBi7wt8eTWrUrKXCOVaFq9x1kgag==}
+
+  has-flag@4.0.0:
+    resolution: {integrity: sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==}
+    engines: {node: '>=8'}
+
+  ignore@5.3.2:
+    resolution: {integrity: sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==}
+    engines: {node: '>= 4'}
+
+  ignore@7.0.5:
+    resolution: {integrity: sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg==}
+    engines: {node: '>= 4'}
+
+  import-fresh@3.3.1:
+    resolution: {integrity: sha512-TR3KfrTZTYLPB6jUjfx6MF9WcWrHL9su5TObK4ZkYgBdWKPOFoSoQIdEuTuR82pmtxH2spWG9h6etwfr1pLBqQ==}
+    engines: {node: '>=6'}
+
+  imurmurhash@0.1.4:
+    resolution: {integrity: sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==}
+    engines: {node: '>=0.8.19'}
+
+  ini@4.1.3:
+    resolution: {integrity: sha512-X7rqawQBvfdjS10YU1y1YVreA3SsLrW9dX2CewP2EbBJM4ypVNLDkO5y04gejPwKIY9lR+7r9gn3rFPt/kmWFg==}
+    engines: {node: ^14.17.0 || ^16.13.0 || >=18.0.0}
+
+  is-alphabetical@2.0.1:
+    resolution: {integrity: sha512-FWyyY60MeTNyeSRpkM2Iry0G9hpr7/9kD40mD/cGQEuilcZYS4okz8SN2Q6rLCJ8gbCt6fN+rC+6tMGS99LaxQ==}
+
+  is-alphanumerical@2.0.1:
+    resolution: {integrity: sha512-hmbYhX/9MUMF5uh7tOXyK/n0ZvWpad5caBA17GsC6vyuCqaWliRG5K1qS9inmUhEMaOBIW7/whAnSwveW/LtZw==}
+
+  is-decimal@2.0.1:
+    resolution: {integrity: sha512-AAB9hiomQs5DXWcRB1rqsxGUstbRroFOPPVAomNk/3XHR5JyEZChOyTWe2oayKnsSsr/kcGqF+z6yuH6HHpN0A==}
+
+  is-extglob@2.1.1:
+    resolution: {integrity: sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==}
+    engines: {node: '>=0.10.0'}
+
+  is-glob@4.0.3:
+    resolution: {integrity: sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==}
+    engines: {node: '>=0.10.0'}
+
+  is-hexadecimal@2.0.1:
+    resolution: {integrity: sha512-DgZQp241c8oO6cA1SbTEWiXeoxV42vlcJxgH+B3hi1AiqqKruZR3ZGF8In3fj4+/y/7rHvlOZLZtgJ/4ttYGZg==}
+
+  is-number@7.0.0:
+    resolution: {integrity: sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==}
+    engines: {node: '>=0.12.0'}
+
+  isexe@2.0.0:
+    resolution: {integrity: sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==}
+
+  js-yaml@4.1.1:
+    resolution: {integrity: sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==}
+    hasBin: true
+
+  json-buffer@3.0.1:
+    resolution: {integrity: sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==}
+
+  json-schema-traverse@0.4.1:
+    resolution: {integrity: sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==}
+
+  json-stable-stringify-without-jsonify@1.0.1:
+    resolution: {integrity: sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==}
+
+  jsonc-parser@3.3.1:
+    resolution: {integrity: sha512-HUgH65KyejrUFPvHFPbqOY0rsFip3Bo5wb4ngvdi1EpCYWUQDC5V+Y7mZws+DLkr4M//zQJoanu1SP+87Dv1oQ==}
+
+  jsonpointer@5.0.1:
+    resolution: {integrity: sha512-p/nXbhSEcu3pZRdkW1OfJhpsVtW1gd4Wa1fnQc9YLiTfAjn0312eMKimbdIQzuZl9aa9xUGaRlP9T/CJE/ditQ==}
+    engines: {node: '>=0.10.0'}
+
+  katex@0.16.47:
+    resolution: {integrity: sha512-Eeo8Ys1doU1z+x8AZsPpQu+p/QcZBI5PeOo7QGQdy2x2m0MU/hYagBbGOmXwr5KVbEfVuWv9LpnQWeehogurjg==}
+    hasBin: true
+
+  keyv@4.5.4:
+    resolution: {integrity: sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==}
+
+  levn@0.4.1:
+    resolution: {integrity: sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==}
+    engines: {node: '>= 0.8.0'}
+
+  linkify-it@5.0.0:
+    resolution: {integrity: sha512-5aHCbzQRADcdP+ATqnDuhhJ/MRIqDkZX5pyjFHRRysS8vZ5AbqGEoFIb6pYHPZ+L/OC2Lc+xT8uHVVR5CAK/wQ==}
+
+  locate-path@6.0.0:
+    resolution: {integrity: sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==}
+    engines: {node: '>=10'}
+
+  lodash.merge@4.6.2:
+    resolution: {integrity: sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==}
+
+  markdown-it@14.1.1:
+    resolution: {integrity: sha512-BuU2qnTti9YKgK5N+IeMubp14ZUKUUw7yeJbkjtosvHiP0AZ5c8IAgEMk79D0eC8F23r4Ac/q8cAIFdm2FtyoA==}
+    hasBin: true
+
+  markdownlint-cli@0.47.0:
+    resolution: {integrity: sha512-HOcxeKFAdDoldvoYDofd85vI8LgNWy8vmYpCwnlLV46PJcodmGzD7COSSBlhHwsfT4o9KrAStGodImVBus31Bg==}
+    engines: {node: '>=20'}
+    hasBin: true
+
+  markdownlint@0.40.0:
+    resolution: {integrity: sha512-UKybllYNheWac61Ia7T6fzuQNDZimFIpCg2w6hHjgV1Qu0w1TV0LlSgryUGzM0bkKQCBhy2FDhEELB73Kb0kAg==}
+    engines: {node: '>=20'}
+
+  mdurl@2.0.0:
+    resolution: {integrity: sha512-Lf+9+2r+Tdp5wXDXC4PcIBjTDtq4UKjCPMQhKIuzpJNW0b96kVqSwW0bT7FhRSfmAiFYgP+SCRvdrDozfh0U5w==}
+
+  merge2@1.4.1:
+    resolution: {integrity: sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==}
+    engines: {node: '>= 8'}
+
+  micromark-core-commonmark@2.0.3:
+    resolution: {integrity: sha512-RDBrHEMSxVFLg6xvnXmb1Ayr2WzLAWjeSATAoxwKYJV94TeNavgoIdA0a9ytzDSVzBy2YKFK+emCPOEibLeCrg==}
+
+  micromark-extension-directive@4.0.0:
+    resolution: {integrity: sha512-/C2nqVmXXmiseSSuCdItCMho7ybwwop6RrrRPk0KbOHW21JKoCldC+8rFOaundDoRBUWBnJJcxeA/Kvi34WQXg==}
+
+  micromark-extension-gfm-autolink-literal@2.1.0:
+    resolution: {integrity: sha512-oOg7knzhicgQ3t4QCjCWgTmfNhvQbDDnJeVu9v81r7NltNCVmhPy1fJRX27pISafdjL+SVc4d3l48Gb6pbRypw==}
+
+  micromark-extension-gfm-footnote@2.1.0:
+    resolution: {integrity: sha512-/yPhxI1ntnDNsiHtzLKYnE3vf9JZ6cAisqVDauhp4CEHxlb4uoOTxOCJ+9s51bIB8U1N1FJ1RXOKTIlD5B/gqw==}
+
+  micromark-extension-gfm-table@2.1.1:
+    resolution: {integrity: sha512-t2OU/dXXioARrC6yWfJ4hqB7rct14e8f7m0cbI5hUmDyyIlwv5vEtooptH8INkbLzOatzKuVbQmAYcbWoyz6Dg==}
+
+  micromark-extension-math@3.1.0:
+    resolution: {integrity: sha512-lvEqd+fHjATVs+2v/8kg9i5Q0AP2k85H0WUOwpIVvUML8BapsMvh1XAogmQjOCsLpoKRCVQqEkQBB3NhVBcsOg==}
+
+  micromark-factory-destination@2.0.1:
+    resolution: {integrity: sha512-Xe6rDdJlkmbFRExpTOmRj9N3MaWmbAgdpSrBQvCFqhezUn4AHqJHbaEnfbVYYiexVSs//tqOdY/DxhjdCiJnIA==}
+
+  micromark-factory-label@2.0.1:
+    resolution: {integrity: sha512-VFMekyQExqIW7xIChcXn4ok29YE3rnuyveW3wZQWWqF4Nv9Wk5rgJ99KzPvHjkmPXF93FXIbBp6YdW3t71/7Vg==}
+
+  micromark-factory-space@2.0.1:
+    resolution: {integrity: sha512-zRkxjtBxxLd2Sc0d+fbnEunsTj46SWXgXciZmHq0kDYGnck/ZSGj9/wULTV95uoeYiK5hRXP2mJ98Uo4cq/LQg==}
+
+  micromark-factory-title@2.0.1:
+    resolution: {integrity: sha512-5bZ+3CjhAd9eChYTHsjy6TGxpOFSKgKKJPJxr293jTbfry2KDoWkhBb6TcPVB4NmzaPhMs1Frm9AZH7OD4Cjzw==}
+
+  micromark-factory-whitespace@2.0.1:
+    resolution: {integrity: sha512-Ob0nuZ3PKt/n0hORHyvoD9uZhr+Za8sFoP+OnMcnWK5lngSzALgQYKMr9RJVOWLqQYuyn6ulqGWSXdwf6F80lQ==}
+
+  micromark-util-character@2.1.1:
+    resolution: {integrity: sha512-wv8tdUTJ3thSFFFJKtpYKOYiGP2+v96Hvk4Tu8KpCAsTMs6yi+nVmGh1syvSCsaxz45J6Jbw+9DD6g97+NV67Q==}
+
+  micromark-util-chunked@2.0.1:
+    resolution: {integrity: sha512-QUNFEOPELfmvv+4xiNg2sRYeS/P84pTW0TCgP5zc9FpXetHY0ab7SxKyAQCNCc1eK0459uoLI1y5oO5Vc1dbhA==}
+
+  micromark-util-classify-character@2.0.1:
+    resolution: {integrity: sha512-K0kHzM6afW/MbeWYWLjoHQv1sgg2Q9EccHEDzSkxiP/EaagNzCm7T/WMKZ3rjMbvIpvBiZgwR3dKMygtA4mG1Q==}
+
+  micromark-util-combine-extensions@2.0.1:
+    resolution: {integrity: sha512-OnAnH8Ujmy59JcyZw8JSbK9cGpdVY44NKgSM7E9Eh7DiLS2E9RNQf0dONaGDzEG9yjEl5hcqeIsj4hfRkLH/Bg==}
+
+  micromark-util-decode-numeric-character-reference@2.0.2:
+    resolution: {integrity: sha512-ccUbYk6CwVdkmCQMyr64dXz42EfHGkPQlBj5p7YVGzq8I7CtjXZJrubAYezf7Rp+bjPseiROqe7G6foFd+lEuw==}
+
+  micromark-util-encode@2.0.1:
+    resolution: {integrity: sha512-c3cVx2y4KqUnwopcO9b/SCdo2O67LwJJ/UyqGfbigahfegL9myoEFoDYZgkT7f36T0bLrM9hZTAaAyH+PCAXjw==}
+
+  micromark-util-html-tag-name@2.0.1:
+    resolution: {integrity: sha512-2cNEiYDhCWKI+Gs9T0Tiysk136SnR13hhO8yW6BGNyhOC4qYFnwF1nKfD3HFAIXA5c45RrIG1ub11GiXeYd1xA==}
+
+  micromark-util-normalize-identifier@2.0.1:
+    resolution: {integrity: sha512-sxPqmo70LyARJs0w2UclACPUUEqltCkJ6PhKdMIDuJ3gSf/Q+/GIe3WKl0Ijb/GyH9lOpUkRAO2wp0GVkLvS9Q==}
+
+  micromark-util-resolve-all@2.0.1:
+    resolution: {integrity: sha512-VdQyxFWFT2/FGJgwQnJYbe1jjQoNTS4RjglmSjTUlpUMa95Htx9NHeYW4rGDJzbjvCsl9eLjMQwGeElsqmzcHg==}
+
+  micromark-util-sanitize-uri@2.0.1:
+    resolution: {integrity: sha512-9N9IomZ/YuGGZZmQec1MbgxtlgougxTodVwDzzEouPKo3qFWvymFHWcnDi2vzV1ff6kas9ucW+o3yzJK9YB1AQ==}
+
+  micromark-util-subtokenize@2.1.0:
+    resolution: {integrity: sha512-XQLu552iSctvnEcgXw6+Sx75GflAPNED1qx7eBJ+wydBb2KCbRZe+NwvIEEMM83uml1+2WSXpBAcp9IUCgCYWA==}
+
+  micromark-util-symbol@2.0.1:
+    resolution: {integrity: sha512-vs5t8Apaud9N28kgCrRUdEed4UJ+wWNvicHLPxCa9ENlYuAY31M0ETy5y1vA33YoNPDFTghEbnh6efaE8h4x0Q==}
+
+  micromark-util-types@2.0.2:
+    resolution: {integrity: sha512-Yw0ECSpJoViF1qTU4DC6NwtC4aWGt1EkzaQB8KPPyCRR8z9TWeV0HbEFGTO+ZY1wB22zmxnJqhPyTpOVCpeHTA==}
+
+  micromark@4.0.2:
+    resolution: {integrity: sha512-zpe98Q6kvavpCr1NPVSCMebCKfD7CA2NqZ+rykeNhONIJBpc1tFKt9hucLGwha3jNTNI8lHpctWJWoimVF4PfA==}
+
+  micromatch@4.0.8:
+    resolution: {integrity: sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==}
+    engines: {node: '>=8.6'}
+
+  minimatch@10.1.3:
+    resolution: {integrity: sha512-IF6URNyBX7Z6XfvjpaNy5meRxPZiIf2OqtOoSLs+hLJ9pJAScnM1RjrFcbCaD85y42KcI+oZmKjFIJKYDFjQfg==}
+    engines: {node: 20 || >=22}
+
+  minimatch@3.1.5:
+    resolution: {integrity: sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==}
+
+  minimatch@9.0.9:
+    resolution: {integrity: sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==}
+    engines: {node: '>=16 || 14 >=14.17'}
+
+  minimist@1.2.8:
+    resolution: {integrity: sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==}
+
+  ms@2.1.3:
+    resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
+
+  natural-compare@1.4.0:
+    resolution: {integrity: sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==}
+
+  optionator@0.9.4:
+    resolution: {integrity: sha512-6IpQ7mKUxRcZNLIObR0hz7lxsapSSIYNZJwXPGeF0mTVqGKFIXj1DQcMoT22S3ROcLyY/rz0PWaWZ9ayWmad9g==}
+    engines: {node: '>= 0.8.0'}
+
+  p-limit@3.1.0:
+    resolution: {integrity: sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==}
+    engines: {node: '>=10'}
+
+  p-locate@5.0.0:
+    resolution: {integrity: sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==}
+    engines: {node: '>=10'}
+
+  parent-module@1.0.1:
+    resolution: {integrity: sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==}
+    engines: {node: '>=6'}
+
+  parse-entities@4.0.2:
+    resolution: {integrity: sha512-GG2AQYWoLgL877gQIKeRPGO1xF9+eG1ujIb5soS5gPvLQ1y2o8FL90w2QWNdf9I361Mpp7726c+lj3U0qK1uGw==}
+
+  path-exists@4.0.0:
+    resolution: {integrity: sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==}
+    engines: {node: '>=8'}
+
+  path-key@3.1.1:
+    resolution: {integrity: sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==}
+    engines: {node: '>=8'}
+
+  picomatch@2.3.2:
+    resolution: {integrity: sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==}
+    engines: {node: '>=8.6'}
+
+  picomatch@4.0.4:
+    resolution: {integrity: sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==}
+    engines: {node: '>=12'}
+
+  prelude-ls@1.2.1:
+    resolution: {integrity: sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==}
+    engines: {node: '>= 0.8.0'}
+
+  prettier@3.6.2:
+    resolution: {integrity: sha512-I7AIg5boAr5R0FFtJ6rCfD+LFsWHp81dolrFD8S79U9tb8Az2nGrJncnMSnys+bpQJfRUzqs9hnA81OAA3hCuQ==}
+    engines: {node: '>=14'}
+    hasBin: true
+
+  punycode.js@2.3.1:
+    resolution: {integrity: sha512-uxFIHU0YlHYhDQtV4R9J6a52SLx28BCjT+4ieh7IGbgwVJWO+km431c4yRlREUAsAmt/uMjQUyQHNEPf0M39CA==}
+    engines: {node: '>=6'}
+
+  punycode@2.3.1:
+    resolution: {integrity: sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==}
+    engines: {node: '>=6'}
+
+  queue-microtask@1.2.3:
+    resolution: {integrity: sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==}
+
+  resolve-from@4.0.0:
+    resolution: {integrity: sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==}
+    engines: {node: '>=4'}
+
+  reusify@1.1.0:
+    resolution: {integrity: sha512-g6QUff04oZpHs0eG5p83rFLhHeV00ug/Yf9nZM6fLeUrPguBTkTQOdpAWWspMh55TZfVQDPaN3NQJfbVRAxdIw==}
+    engines: {iojs: '>=1.0.0', node: '>=0.10.0'}
+
+  run-con@1.3.2:
+    resolution: {integrity: sha512-CcfE+mYiTcKEzg0IqS08+efdnH0oJ3zV0wSUFBNrMHMuxCtXvBCLzCJHatwuXDcu/RlhjTziTo/a1ruQik6/Yg==}
+    hasBin: true
+
+  run-parallel@1.2.0:
+    resolution: {integrity: sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==}
+
+  semver@7.8.0:
+    resolution: {integrity: sha512-AcM7dV/5ul4EekoQ29Agm5vri8JNqRyj39o0qpX6vDF2GZrtutZl5RwgD1XnZjiTAfncsJhMI48QQH3sN87YNA==}
+    engines: {node: '>=10'}
+    hasBin: true
+
+  shebang-command@2.0.0:
+    resolution: {integrity: sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==}
+    engines: {node: '>=8'}
+
+  shebang-regex@3.0.0:
+    resolution: {integrity: sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==}
+    engines: {node: '>=8'}
+
+  smol-toml@1.5.2:
+    resolution: {integrity: sha512-QlaZEqcAH3/RtNyet1IPIYPsEWAaYyXXv1Krsi+1L/QHppjX4Ifm8MQsBISz9vE8cHicIq3clogsheili5vhaQ==}
+    engines: {node: '>= 18'}
+
+  string-width@8.1.0:
+    resolution: {integrity: sha512-Kxl3KJGb/gxkaUMOjRsQ8IrXiGW75O4E3RPjFIINOVH8AMl2SQ/yWdTzWwF3FevIX9LcMAjJW+GRwAlAbTSXdg==}
+    engines: {node: '>=20'}
+
+  strip-ansi@7.2.0:
+    resolution: {integrity: sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==}
+    engines: {node: '>=12'}
+
+  strip-json-comments@3.1.1:
+    resolution: {integrity: sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==}
+    engines: {node: '>=8'}
+
+  supports-color@7.2.0:
+    resolution: {integrity: sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==}
+    engines: {node: '>=8'}
+
+  tinyglobby@0.2.16:
+    resolution: {integrity: sha512-pn99VhoACYR8nFHhxqix+uvsbXineAasWm5ojXoN8xEwK5Kd3/TrhNn1wByuD52UxWRLy8pu+kRMniEi6Eq9Zg==}
+    engines: {node: '>=12.0.0'}
+
+  to-regex-range@5.0.1:
+    resolution: {integrity: sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==}
+    engines: {node: '>=8.0'}
+
+  ts-api-utils@2.5.0:
+    resolution: {integrity: sha512-OJ/ibxhPlqrMM0UiNHJ/0CKQkoKF243/AEmplt3qpRgkW8VG7IfOS41h7V8TjITqdByHzrjcS/2si+y4lIh8NA==}
+    engines: {node: '>=18.12'}
+    peerDependencies:
+      typescript: '>=4.8.4'
+
   turbo@2.9.14:
     resolution: {integrity: sha512-BQqXRr4UoWI3UPFrtznCLykYHxwxWh53iCB57x092jPMjIlW1wnm3N895g5irpiXmnxUhREBB0n6+y8BHhs4nw==}
     hasBin: true
 
+  type-check@0.4.0:
+    resolution: {integrity: sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==}
+    engines: {node: '>= 0.8.0'}
+
+  typescript@5.9.3:
+    resolution: {integrity: sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==}
+    engines: {node: '>=14.17'}
+    hasBin: true
+
+  uc.micro@2.1.0:
+    resolution: {integrity: sha512-ARDJmphmdvUk6Glw7y9DQ2bFkKBHwQHLi2lsaH6PPmz/Ka9sFOBsBluozhDltWmnv9u/cF6Rt87znRTPV+yp/A==}
+
+  uri-js@4.4.1:
+    resolution: {integrity: sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==}
+
+  which@2.0.2:
+    resolution: {integrity: sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==}
+    engines: {node: '>= 8'}
+    hasBin: true
+
+  word-wrap@1.2.5:
+    resolution: {integrity: sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==}
+    engines: {node: '>=0.10.0'}
+
+  yocto-queue@0.1.0:
+    resolution: {integrity: sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==}
+    engines: {node: '>=10'}
+
 snapshots:
 
+  '@eslint-community/eslint-utils@4.9.1(eslint@9.34.0)':
+    dependencies:
+      eslint: 9.34.0
+      eslint-visitor-keys: 3.4.3
+
+  '@eslint-community/regexpp@4.12.2': {}
+
+  '@eslint/config-array@0.21.2':
+    dependencies:
+      '@eslint/object-schema': 2.1.7
+      debug: 4.4.3
+      minimatch: 3.1.5
+    transitivePeerDependencies:
+      - supports-color
+
+  '@eslint/config-helpers@0.3.1': {}
+
+  '@eslint/core@0.15.2':
+    dependencies:
+      '@types/json-schema': 7.0.15
+
+  '@eslint/eslintrc@3.3.5':
+    dependencies:
+      ajv: 6.15.0
+      debug: 4.4.3
+      espree: 10.4.0
+      globals: 14.0.0
+      ignore: 5.3.2
+      import-fresh: 3.3.1
+      js-yaml: 4.1.1
+      minimatch: 3.1.5
+      strip-json-comments: 3.1.1
+    transitivePeerDependencies:
+      - supports-color
+
+  '@eslint/js@9.34.0': {}
+
+  '@eslint/object-schema@2.1.7': {}
+
+  '@eslint/plugin-kit@0.3.5':
+    dependencies:
+      '@eslint/core': 0.15.2
+      levn: 0.4.1
+
   '@foomakers/pair-cli@0.4.3': {}
+
+  '@humanfs/core@0.19.2':
+    dependencies:
+      '@humanfs/types': 0.15.0
+
+  '@humanfs/node@0.16.8':
+    dependencies:
+      '@humanfs/core': 0.19.2
+      '@humanfs/types': 0.15.0
+      '@humanwhocodes/retry': 0.4.3
+
+  '@humanfs/types@0.15.0': {}
+
+  '@humanwhocodes/module-importer@1.0.1': {}
+
+  '@humanwhocodes/retry@0.4.3': {}
+
+  '@nodelib/fs.scandir@2.1.5':
+    dependencies:
+      '@nodelib/fs.stat': 2.0.5
+      run-parallel: 1.2.0
+
+  '@nodelib/fs.stat@2.0.5': {}
+
+  '@nodelib/fs.walk@1.2.8':
+    dependencies:
+      '@nodelib/fs.scandir': 2.1.5
+      fastq: 1.20.1
 
   '@turbo/darwin-64@2.9.14':
     optional: true
@@ -86,6 +941,747 @@ snapshots:
   '@turbo/windows-arm64@2.9.14':
     optional: true
 
+  '@types/debug@4.1.13':
+    dependencies:
+      '@types/ms': 2.1.0
+
+  '@types/estree@1.0.9': {}
+
+  '@types/json-schema@7.0.15': {}
+
+  '@types/katex@0.16.8': {}
+
+  '@types/ms@2.1.0': {}
+
+  '@types/unist@2.0.11': {}
+
+  '@typescript-eslint/eslint-plugin@8.41.0(@typescript-eslint/parser@8.41.0(eslint@9.34.0)(typescript@5.9.3))(eslint@9.34.0)(typescript@5.9.3)':
+    dependencies:
+      '@eslint-community/regexpp': 4.12.2
+      '@typescript-eslint/parser': 8.41.0(eslint@9.34.0)(typescript@5.9.3)
+      '@typescript-eslint/scope-manager': 8.41.0
+      '@typescript-eslint/type-utils': 8.41.0(eslint@9.34.0)(typescript@5.9.3)
+      '@typescript-eslint/utils': 8.41.0(eslint@9.34.0)(typescript@5.9.3)
+      '@typescript-eslint/visitor-keys': 8.41.0
+      eslint: 9.34.0
+      graphemer: 1.4.0
+      ignore: 7.0.5
+      natural-compare: 1.4.0
+      ts-api-utils: 2.5.0(typescript@5.9.3)
+      typescript: 5.9.3
+    transitivePeerDependencies:
+      - supports-color
+
+  '@typescript-eslint/parser@8.41.0(eslint@9.34.0)(typescript@5.9.3)':
+    dependencies:
+      '@typescript-eslint/scope-manager': 8.41.0
+      '@typescript-eslint/types': 8.41.0
+      '@typescript-eslint/typescript-estree': 8.41.0(typescript@5.9.3)
+      '@typescript-eslint/visitor-keys': 8.41.0
+      debug: 4.4.3
+      eslint: 9.34.0
+      typescript: 5.9.3
+    transitivePeerDependencies:
+      - supports-color
+
+  '@typescript-eslint/project-service@8.41.0(typescript@5.9.3)':
+    dependencies:
+      '@typescript-eslint/tsconfig-utils': 8.41.0(typescript@5.9.3)
+      '@typescript-eslint/types': 8.41.0
+      debug: 4.4.3
+      typescript: 5.9.3
+    transitivePeerDependencies:
+      - supports-color
+
+  '@typescript-eslint/scope-manager@8.41.0':
+    dependencies:
+      '@typescript-eslint/types': 8.41.0
+      '@typescript-eslint/visitor-keys': 8.41.0
+
+  '@typescript-eslint/tsconfig-utils@8.41.0(typescript@5.9.3)':
+    dependencies:
+      typescript: 5.9.3
+
+  '@typescript-eslint/type-utils@8.41.0(eslint@9.34.0)(typescript@5.9.3)':
+    dependencies:
+      '@typescript-eslint/types': 8.41.0
+      '@typescript-eslint/typescript-estree': 8.41.0(typescript@5.9.3)
+      '@typescript-eslint/utils': 8.41.0(eslint@9.34.0)(typescript@5.9.3)
+      debug: 4.4.3
+      eslint: 9.34.0
+      ts-api-utils: 2.5.0(typescript@5.9.3)
+      typescript: 5.9.3
+    transitivePeerDependencies:
+      - supports-color
+
+  '@typescript-eslint/types@8.41.0': {}
+
+  '@typescript-eslint/typescript-estree@8.41.0(typescript@5.9.3)':
+    dependencies:
+      '@typescript-eslint/project-service': 8.41.0(typescript@5.9.3)
+      '@typescript-eslint/tsconfig-utils': 8.41.0(typescript@5.9.3)
+      '@typescript-eslint/types': 8.41.0
+      '@typescript-eslint/visitor-keys': 8.41.0
+      debug: 4.4.3
+      fast-glob: 3.3.3
+      is-glob: 4.0.3
+      minimatch: 9.0.9
+      semver: 7.8.0
+      ts-api-utils: 2.5.0(typescript@5.9.3)
+      typescript: 5.9.3
+    transitivePeerDependencies:
+      - supports-color
+
+  '@typescript-eslint/utils@8.41.0(eslint@9.34.0)(typescript@5.9.3)':
+    dependencies:
+      '@eslint-community/eslint-utils': 4.9.1(eslint@9.34.0)
+      '@typescript-eslint/scope-manager': 8.41.0
+      '@typescript-eslint/types': 8.41.0
+      '@typescript-eslint/typescript-estree': 8.41.0(typescript@5.9.3)
+      eslint: 9.34.0
+      typescript: 5.9.3
+    transitivePeerDependencies:
+      - supports-color
+
+  '@typescript-eslint/visitor-keys@8.41.0':
+    dependencies:
+      '@typescript-eslint/types': 8.41.0
+      eslint-visitor-keys: 4.2.1
+
+  acorn-jsx@5.3.2(acorn@8.16.0):
+    dependencies:
+      acorn: 8.16.0
+
+  acorn@8.16.0: {}
+
+  ajv@6.15.0:
+    dependencies:
+      fast-deep-equal: 3.1.3
+      fast-json-stable-stringify: 2.1.0
+      json-schema-traverse: 0.4.1
+      uri-js: 4.4.1
+
+  ansi-regex@6.2.2: {}
+
+  ansi-styles@4.3.0:
+    dependencies:
+      color-convert: 2.0.1
+
+  argparse@2.0.1: {}
+
+  balanced-match@1.0.2: {}
+
+  balanced-match@4.0.4: {}
+
+  brace-expansion@1.1.14:
+    dependencies:
+      balanced-match: 1.0.2
+      concat-map: 0.0.1
+
+  brace-expansion@2.1.0:
+    dependencies:
+      balanced-match: 1.0.2
+
+  brace-expansion@5.0.6:
+    dependencies:
+      balanced-match: 4.0.4
+
+  braces@3.0.3:
+    dependencies:
+      fill-range: 7.1.1
+
+  callsites@3.1.0: {}
+
+  chalk@4.1.2:
+    dependencies:
+      ansi-styles: 4.3.0
+      supports-color: 7.2.0
+
+  character-entities-legacy@3.0.0: {}
+
+  character-entities@2.0.2: {}
+
+  character-reference-invalid@2.0.1: {}
+
+  color-convert@2.0.1:
+    dependencies:
+      color-name: 1.1.4
+
+  color-name@1.1.4: {}
+
+  commander@14.0.3: {}
+
+  commander@8.3.0: {}
+
+  concat-map@0.0.1: {}
+
+  cross-spawn@7.0.6:
+    dependencies:
+      path-key: 3.1.1
+      shebang-command: 2.0.0
+      which: 2.0.2
+
+  debug@4.4.3:
+    dependencies:
+      ms: 2.1.3
+
+  decode-named-character-reference@1.3.0:
+    dependencies:
+      character-entities: 2.0.2
+
+  deep-extend@0.6.0: {}
+
+  deep-is@0.1.4: {}
+
+  dequal@2.0.3: {}
+
+  devlop@1.1.0:
+    dependencies:
+      dequal: 2.0.3
+
+  entities@4.5.0: {}
+
+  escape-string-regexp@4.0.0: {}
+
+  eslint-scope@8.4.0:
+    dependencies:
+      esrecurse: 4.3.0
+      estraverse: 5.3.0
+
+  eslint-visitor-keys@3.4.3: {}
+
+  eslint-visitor-keys@4.2.1: {}
+
+  eslint@9.34.0:
+    dependencies:
+      '@eslint-community/eslint-utils': 4.9.1(eslint@9.34.0)
+      '@eslint-community/regexpp': 4.12.2
+      '@eslint/config-array': 0.21.2
+      '@eslint/config-helpers': 0.3.1
+      '@eslint/core': 0.15.2
+      '@eslint/eslintrc': 3.3.5
+      '@eslint/js': 9.34.0
+      '@eslint/plugin-kit': 0.3.5
+      '@humanfs/node': 0.16.8
+      '@humanwhocodes/module-importer': 1.0.1
+      '@humanwhocodes/retry': 0.4.3
+      '@types/estree': 1.0.9
+      '@types/json-schema': 7.0.15
+      ajv: 6.15.0
+      chalk: 4.1.2
+      cross-spawn: 7.0.6
+      debug: 4.4.3
+      escape-string-regexp: 4.0.0
+      eslint-scope: 8.4.0
+      eslint-visitor-keys: 4.2.1
+      espree: 10.4.0
+      esquery: 1.7.0
+      esutils: 2.0.3
+      fast-deep-equal: 3.1.3
+      file-entry-cache: 8.0.0
+      find-up: 5.0.0
+      glob-parent: 6.0.2
+      ignore: 5.3.2
+      imurmurhash: 0.1.4
+      is-glob: 4.0.3
+      json-stable-stringify-without-jsonify: 1.0.1
+      lodash.merge: 4.6.2
+      minimatch: 3.1.5
+      natural-compare: 1.4.0
+      optionator: 0.9.4
+    transitivePeerDependencies:
+      - supports-color
+
+  espree@10.4.0:
+    dependencies:
+      acorn: 8.16.0
+      acorn-jsx: 5.3.2(acorn@8.16.0)
+      eslint-visitor-keys: 4.2.1
+
+  esquery@1.7.0:
+    dependencies:
+      estraverse: 5.3.0
+
+  esrecurse@4.3.0:
+    dependencies:
+      estraverse: 5.3.0
+
+  estraverse@5.3.0: {}
+
+  esutils@2.0.3: {}
+
+  fast-deep-equal@3.1.3: {}
+
+  fast-glob@3.3.3:
+    dependencies:
+      '@nodelib/fs.stat': 2.0.5
+      '@nodelib/fs.walk': 1.2.8
+      glob-parent: 5.1.2
+      merge2: 1.4.1
+      micromatch: 4.0.8
+
+  fast-json-stable-stringify@2.1.0: {}
+
+  fast-levenshtein@2.0.6: {}
+
+  fastq@1.20.1:
+    dependencies:
+      reusify: 1.1.0
+
+  fdir@6.5.0(picomatch@4.0.4):
+    optionalDependencies:
+      picomatch: 4.0.4
+
+  file-entry-cache@8.0.0:
+    dependencies:
+      flat-cache: 4.0.1
+
+  fill-range@7.1.1:
+    dependencies:
+      to-regex-range: 5.0.1
+
+  find-up@5.0.0:
+    dependencies:
+      locate-path: 6.0.0
+      path-exists: 4.0.0
+
+  flat-cache@4.0.1:
+    dependencies:
+      flatted: 3.4.2
+      keyv: 4.5.4
+
+  flatted@3.4.2: {}
+
+  get-east-asian-width@1.6.0: {}
+
+  glob-parent@5.1.2:
+    dependencies:
+      is-glob: 4.0.3
+
+  glob-parent@6.0.2:
+    dependencies:
+      is-glob: 4.0.3
+
+  globals@14.0.0: {}
+
+  globals@15.0.0: {}
+
+  graphemer@1.4.0: {}
+
+  has-flag@4.0.0: {}
+
+  ignore@5.3.2: {}
+
+  ignore@7.0.5: {}
+
+  import-fresh@3.3.1:
+    dependencies:
+      parent-module: 1.0.1
+      resolve-from: 4.0.0
+
+  imurmurhash@0.1.4: {}
+
+  ini@4.1.3: {}
+
+  is-alphabetical@2.0.1: {}
+
+  is-alphanumerical@2.0.1:
+    dependencies:
+      is-alphabetical: 2.0.1
+      is-decimal: 2.0.1
+
+  is-decimal@2.0.1: {}
+
+  is-extglob@2.1.1: {}
+
+  is-glob@4.0.3:
+    dependencies:
+      is-extglob: 2.1.1
+
+  is-hexadecimal@2.0.1: {}
+
+  is-number@7.0.0: {}
+
+  isexe@2.0.0: {}
+
+  js-yaml@4.1.1:
+    dependencies:
+      argparse: 2.0.1
+
+  json-buffer@3.0.1: {}
+
+  json-schema-traverse@0.4.1: {}
+
+  json-stable-stringify-without-jsonify@1.0.1: {}
+
+  jsonc-parser@3.3.1: {}
+
+  jsonpointer@5.0.1: {}
+
+  katex@0.16.47:
+    dependencies:
+      commander: 8.3.0
+
+  keyv@4.5.4:
+    dependencies:
+      json-buffer: 3.0.1
+
+  levn@0.4.1:
+    dependencies:
+      prelude-ls: 1.2.1
+      type-check: 0.4.0
+
+  linkify-it@5.0.0:
+    dependencies:
+      uc.micro: 2.1.0
+
+  locate-path@6.0.0:
+    dependencies:
+      p-locate: 5.0.0
+
+  lodash.merge@4.6.2: {}
+
+  markdown-it@14.1.1:
+    dependencies:
+      argparse: 2.0.1
+      entities: 4.5.0
+      linkify-it: 5.0.0
+      mdurl: 2.0.0
+      punycode.js: 2.3.1
+      uc.micro: 2.1.0
+
+  markdownlint-cli@0.47.0:
+    dependencies:
+      commander: 14.0.3
+      deep-extend: 0.6.0
+      ignore: 7.0.5
+      js-yaml: 4.1.1
+      jsonc-parser: 3.3.1
+      jsonpointer: 5.0.1
+      markdown-it: 14.1.1
+      markdownlint: 0.40.0
+      minimatch: 10.1.3
+      run-con: 1.3.2
+      smol-toml: 1.5.2
+      tinyglobby: 0.2.16
+    transitivePeerDependencies:
+      - supports-color
+
+  markdownlint@0.40.0:
+    dependencies:
+      micromark: 4.0.2
+      micromark-core-commonmark: 2.0.3
+      micromark-extension-directive: 4.0.0
+      micromark-extension-gfm-autolink-literal: 2.1.0
+      micromark-extension-gfm-footnote: 2.1.0
+      micromark-extension-gfm-table: 2.1.1
+      micromark-extension-math: 3.1.0
+      micromark-util-types: 2.0.2
+      string-width: 8.1.0
+    transitivePeerDependencies:
+      - supports-color
+
+  mdurl@2.0.0: {}
+
+  merge2@1.4.1: {}
+
+  micromark-core-commonmark@2.0.3:
+    dependencies:
+      decode-named-character-reference: 1.3.0
+      devlop: 1.1.0
+      micromark-factory-destination: 2.0.1
+      micromark-factory-label: 2.0.1
+      micromark-factory-space: 2.0.1
+      micromark-factory-title: 2.0.1
+      micromark-factory-whitespace: 2.0.1
+      micromark-util-character: 2.1.1
+      micromark-util-chunked: 2.0.1
+      micromark-util-classify-character: 2.0.1
+      micromark-util-html-tag-name: 2.0.1
+      micromark-util-normalize-identifier: 2.0.1
+      micromark-util-resolve-all: 2.0.1
+      micromark-util-subtokenize: 2.1.0
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-extension-directive@4.0.0:
+    dependencies:
+      devlop: 1.1.0
+      micromark-factory-space: 2.0.1
+      micromark-factory-whitespace: 2.0.1
+      micromark-util-character: 2.1.1
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+      parse-entities: 4.0.2
+
+  micromark-extension-gfm-autolink-literal@2.1.0:
+    dependencies:
+      micromark-util-character: 2.1.1
+      micromark-util-sanitize-uri: 2.0.1
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-extension-gfm-footnote@2.1.0:
+    dependencies:
+      devlop: 1.1.0
+      micromark-core-commonmark: 2.0.3
+      micromark-factory-space: 2.0.1
+      micromark-util-character: 2.1.1
+      micromark-util-normalize-identifier: 2.0.1
+      micromark-util-sanitize-uri: 2.0.1
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-extension-gfm-table@2.1.1:
+    dependencies:
+      devlop: 1.1.0
+      micromark-factory-space: 2.0.1
+      micromark-util-character: 2.1.1
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-extension-math@3.1.0:
+    dependencies:
+      '@types/katex': 0.16.8
+      devlop: 1.1.0
+      katex: 0.16.47
+      micromark-factory-space: 2.0.1
+      micromark-util-character: 2.1.1
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-factory-destination@2.0.1:
+    dependencies:
+      micromark-util-character: 2.1.1
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-factory-label@2.0.1:
+    dependencies:
+      devlop: 1.1.0
+      micromark-util-character: 2.1.1
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-factory-space@2.0.1:
+    dependencies:
+      micromark-util-character: 2.1.1
+      micromark-util-types: 2.0.2
+
+  micromark-factory-title@2.0.1:
+    dependencies:
+      micromark-factory-space: 2.0.1
+      micromark-util-character: 2.1.1
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-factory-whitespace@2.0.1:
+    dependencies:
+      micromark-factory-space: 2.0.1
+      micromark-util-character: 2.1.1
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-util-character@2.1.1:
+    dependencies:
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-util-chunked@2.0.1:
+    dependencies:
+      micromark-util-symbol: 2.0.1
+
+  micromark-util-classify-character@2.0.1:
+    dependencies:
+      micromark-util-character: 2.1.1
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-util-combine-extensions@2.0.1:
+    dependencies:
+      micromark-util-chunked: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-util-decode-numeric-character-reference@2.0.2:
+    dependencies:
+      micromark-util-symbol: 2.0.1
+
+  micromark-util-encode@2.0.1: {}
+
+  micromark-util-html-tag-name@2.0.1: {}
+
+  micromark-util-normalize-identifier@2.0.1:
+    dependencies:
+      micromark-util-symbol: 2.0.1
+
+  micromark-util-resolve-all@2.0.1:
+    dependencies:
+      micromark-util-types: 2.0.2
+
+  micromark-util-sanitize-uri@2.0.1:
+    dependencies:
+      micromark-util-character: 2.1.1
+      micromark-util-encode: 2.0.1
+      micromark-util-symbol: 2.0.1
+
+  micromark-util-subtokenize@2.1.0:
+    dependencies:
+      devlop: 1.1.0
+      micromark-util-chunked: 2.0.1
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-util-symbol@2.0.1: {}
+
+  micromark-util-types@2.0.2: {}
+
+  micromark@4.0.2:
+    dependencies:
+      '@types/debug': 4.1.13
+      debug: 4.4.3
+      decode-named-character-reference: 1.3.0
+      devlop: 1.1.0
+      micromark-core-commonmark: 2.0.3
+      micromark-factory-space: 2.0.1
+      micromark-util-character: 2.1.1
+      micromark-util-chunked: 2.0.1
+      micromark-util-combine-extensions: 2.0.1
+      micromark-util-decode-numeric-character-reference: 2.0.2
+      micromark-util-encode: 2.0.1
+      micromark-util-normalize-identifier: 2.0.1
+      micromark-util-resolve-all: 2.0.1
+      micromark-util-sanitize-uri: 2.0.1
+      micromark-util-subtokenize: 2.1.0
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+    transitivePeerDependencies:
+      - supports-color
+
+  micromatch@4.0.8:
+    dependencies:
+      braces: 3.0.3
+      picomatch: 2.3.2
+
+  minimatch@10.1.3:
+    dependencies:
+      brace-expansion: 5.0.6
+
+  minimatch@3.1.5:
+    dependencies:
+      brace-expansion: 1.1.14
+
+  minimatch@9.0.9:
+    dependencies:
+      brace-expansion: 2.1.0
+
+  minimist@1.2.8: {}
+
+  ms@2.1.3: {}
+
+  natural-compare@1.4.0: {}
+
+  optionator@0.9.4:
+    dependencies:
+      deep-is: 0.1.4
+      fast-levenshtein: 2.0.6
+      levn: 0.4.1
+      prelude-ls: 1.2.1
+      type-check: 0.4.0
+      word-wrap: 1.2.5
+
+  p-limit@3.1.0:
+    dependencies:
+      yocto-queue: 0.1.0
+
+  p-locate@5.0.0:
+    dependencies:
+      p-limit: 3.1.0
+
+  parent-module@1.0.1:
+    dependencies:
+      callsites: 3.1.0
+
+  parse-entities@4.0.2:
+    dependencies:
+      '@types/unist': 2.0.11
+      character-entities-legacy: 3.0.0
+      character-reference-invalid: 2.0.1
+      decode-named-character-reference: 1.3.0
+      is-alphanumerical: 2.0.1
+      is-decimal: 2.0.1
+      is-hexadecimal: 2.0.1
+
+  path-exists@4.0.0: {}
+
+  path-key@3.1.1: {}
+
+  picomatch@2.3.2: {}
+
+  picomatch@4.0.4: {}
+
+  prelude-ls@1.2.1: {}
+
+  prettier@3.6.2: {}
+
+  punycode.js@2.3.1: {}
+
+  punycode@2.3.1: {}
+
+  queue-microtask@1.2.3: {}
+
+  resolve-from@4.0.0: {}
+
+  reusify@1.1.0: {}
+
+  run-con@1.3.2:
+    dependencies:
+      deep-extend: 0.6.0
+      ini: 4.1.3
+      minimist: 1.2.8
+      strip-json-comments: 3.1.1
+
+  run-parallel@1.2.0:
+    dependencies:
+      queue-microtask: 1.2.3
+
+  semver@7.8.0: {}
+
+  shebang-command@2.0.0:
+    dependencies:
+      shebang-regex: 3.0.0
+
+  shebang-regex@3.0.0: {}
+
+  smol-toml@1.5.2: {}
+
+  string-width@8.1.0:
+    dependencies:
+      get-east-asian-width: 1.6.0
+      strip-ansi: 7.2.0
+
+  strip-ansi@7.2.0:
+    dependencies:
+      ansi-regex: 6.2.2
+
+  strip-json-comments@3.1.1: {}
+
+  supports-color@7.2.0:
+    dependencies:
+      has-flag: 4.0.0
+
+  tinyglobby@0.2.16:
+    dependencies:
+      fdir: 6.5.0(picomatch@4.0.4)
+      picomatch: 4.0.4
+
+  to-regex-range@5.0.1:
+    dependencies:
+      is-number: 7.0.0
+
+  ts-api-utils@2.5.0(typescript@5.9.3):
+    dependencies:
+      typescript: 5.9.3
+
   turbo@2.9.14:
     optionalDependencies:
       '@turbo/darwin-64': 2.9.14
@@ -94,3 +1690,23 @@ snapshots:
       '@turbo/linux-arm64': 2.9.14
       '@turbo/windows-64': 2.9.14
       '@turbo/windows-arm64': 2.9.14
+
+  type-check@0.4.0:
+    dependencies:
+      prelude-ls: 1.2.1
+
+  typescript@5.9.3: {}
+
+  uc.micro@2.1.0: {}
+
+  uri-js@4.4.1:
+    dependencies:
+      punycode: 2.3.1
+
+  which@2.0.2:
+    dependencies:
+      isexe: 2.0.0
+
+  word-wrap@1.2.5: {}
+
+  yocto-queue@0.1.0: {}

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -13,6 +13,5 @@ catalog:
   markdownlint-cli: 0.47.0
   prettier: 3.6.2
   turbo: "^2.3.3"
-  typescript: 5.4.5
 
 cleanupUnusedCatalogs: true

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -4,7 +4,15 @@ packages:
   - "tools/*"
 
 catalog:
+  "@eslint/js": 9.34.0
   "@foomakers/pair-cli": "^0.4.3"
+  "@typescript-eslint/eslint-plugin": 8.41.0
+  "@typescript-eslint/parser": 8.41.0
+  eslint: 9.34.0
+  globals: 15.0.0
+  markdownlint-cli: 0.47.0
+  prettier: 3.6.2
   turbo: "^2.3.3"
+  typescript: 5.4.5
 
 cleanupUnusedCatalogs: true

--- a/tools/eslint-config/.eslintignore
+++ b/tools/eslint-config/.eslintignore
@@ -1,0 +1,3 @@
+dist/
+build/
+node_modules/

--- a/tools/eslint-config/.eslintignore
+++ b/tools/eslint-config/.eslintignore
@@ -1,3 +1,0 @@
-dist/
-build/
-node_modules/

--- a/tools/eslint-config/README.md
+++ b/tools/eslint-config/README.md
@@ -1,0 +1,49 @@
+# @gilberto/eslint-config
+
+Shared ESLint configuration for the pair monorepo. All packages use these rules by default unless they provide their own config.
+
+## Usage
+
+Reference in your package's `package.json` scripts (via the `lint` / `lint-fix` bin wrappers):
+
+```json
+"scripts": {
+  "lint": "lint",
+  "lint:fix": "lint-fix"
+}
+```
+
+Or extend directly in a custom config:
+
+```js
+module.exports = require('@gilberto/eslint-config')
+```
+
+### Available Configs
+
+| Config | Import | Use Case |
+|--------|--------|----------|
+| Base | `@gilberto/eslint-config` | TypeScript packages |
+| React | `@gilberto/eslint-config/react` | React packages |
+| React + a11y | `@gilberto/eslint-config/react-a11y` | React with accessibility rules |
+
+### Extending in a Package
+
+Create an `eslint.config.cjs` in your package root:
+
+```js
+module.exports = {
+  extends: [require.resolve('@gilberto/eslint-config')],
+  rules: {
+    // package-specific overrides
+  },
+}
+```
+
+## Files
+
+- `index.js` — base config (TypeScript + general rules)
+- `react.js` — React plugin rules
+- `react-a11y.js` — React + jsx-a11y rules
+- `bin/` — wrapper scripts (`lint`, `lint-fix`, `eslint`)
+- `.eslintignore` — ignored patterns

--- a/tools/eslint-config/README.md
+++ b/tools/eslint-config/README.md
@@ -1,6 +1,6 @@
 # @gilberto/eslint-config
 
-Shared ESLint configuration for the pair monorepo. All packages use these rules by default unless they provide their own config.
+Shared ESLint flat-config for the gilberto monorepo. All packages use these rules by default unless they provide their own config.
 
 ## Usage
 
@@ -13,37 +13,30 @@ Reference in your package's `package.json` scripts (via the `lint` / `lint-fix` 
 }
 ```
 
-Or extend directly in a custom config:
+Or extend directly in a custom flat config:
 
 ```js
-module.exports = require('@gilberto/eslint-config')
+const base = require('@gilberto/eslint-config')
+
+module.exports = [
+  ...base,
+  {
+    rules: {
+      // package-specific overrides
+    },
+  },
+]
 ```
 
 ### Available Configs
 
-| Config | Import | Use Case |
-|--------|--------|----------|
-| Base | `@gilberto/eslint-config` | TypeScript packages |
-| React | `@gilberto/eslint-config/react` | React packages |
-| React + a11y | `@gilberto/eslint-config/react-a11y` | React with accessibility rules |
-
-### Extending in a Package
-
-Create an `eslint.config.cjs` in your package root:
-
-```js
-module.exports = {
-  extends: [require.resolve('@gilberto/eslint-config')],
-  rules: {
-    // package-specific overrides
-  },
-}
-```
+| Config | Import | Use Case | Status |
+|--------|--------|----------|--------|
+| Base | `@gilberto/eslint-config` | TypeScript packages | Available |
+| React | `@gilberto/eslint-config/react` | React packages | Deferred — lands with `apps/website/` (Phase 5, Initiative #5) |
+| React + a11y | `@gilberto/eslint-config/react-a11y` | React with accessibility rules | Deferred — lands with `apps/website/` (Phase 5, Initiative #5) |
 
 ## Files
 
-- `index.js` — base config (TypeScript + general rules)
-- `react.js` — React plugin rules
-- `react-a11y.js` — React + jsx-a11y rules
+- `eslint.config.cjs` — base flat config (TypeScript + general rules); also encodes the ignore patterns inline
 - `bin/` — wrapper scripts (`lint`, `lint-fix`, `eslint`)
-- `.eslintignore` — ignored patterns

--- a/tools/eslint-config/bin/eslint.sh
+++ b/tools/eslint-config/bin/eslint.sh
@@ -1,0 +1,3 @@
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+ESLINT_BIN="$SCRIPT_DIR/../node_modules/.bin/eslint"
+$ESLINT_BIN "$@" 

--- a/tools/eslint-config/bin/eslint.sh
+++ b/tools/eslint-config/bin/eslint.sh
@@ -1,3 +1,6 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 ESLINT_BIN="$SCRIPT_DIR/../node_modules/.bin/eslint"
-$ESLINT_BIN "$@" 
+"$ESLINT_BIN" "$@"

--- a/tools/eslint-config/bin/lint-fix.sh
+++ b/tools/eslint-config/bin/lint-fix.sh
@@ -1,0 +1,4 @@
+WORKSPACE_ROOT="$(pwd)"
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+ESLINT_BIN="$SCRIPT_DIR/../node_modules/.bin/eslint"
+$ESLINT_BIN "$WORKSPACE_ROOT/." --config "$SCRIPT_DIR/../eslint.config.cjs" --fix

--- a/tools/eslint-config/bin/lint-fix.sh
+++ b/tools/eslint-config/bin/lint-fix.sh
@@ -1,4 +1,7 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
 WORKSPACE_ROOT="$(pwd)"
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 ESLINT_BIN="$SCRIPT_DIR/../node_modules/.bin/eslint"
-$ESLINT_BIN "$WORKSPACE_ROOT/." --config "$SCRIPT_DIR/../eslint.config.cjs" --fix
+"$ESLINT_BIN" "$WORKSPACE_ROOT/." --config "$SCRIPT_DIR/../eslint.config.cjs" --fix

--- a/tools/eslint-config/bin/lint.sh
+++ b/tools/eslint-config/bin/lint.sh
@@ -1,0 +1,4 @@
+WORKSPACE_ROOT="$(pwd)"
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+ESLINT_BIN="$SCRIPT_DIR/../node_modules/.bin/eslint"
+$ESLINT_BIN "$WORKSPACE_ROOT/." --config "$SCRIPT_DIR/../eslint.config.cjs"

--- a/tools/eslint-config/bin/lint.sh
+++ b/tools/eslint-config/bin/lint.sh
@@ -1,4 +1,7 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
 WORKSPACE_ROOT="$(pwd)"
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 ESLINT_BIN="$SCRIPT_DIR/../node_modules/.bin/eslint"
-$ESLINT_BIN "$WORKSPACE_ROOT/." --config "$SCRIPT_DIR/../eslint.config.cjs"
+"$ESLINT_BIN" "$WORKSPACE_ROOT/." --config "$SCRIPT_DIR/../eslint.config.cjs"

--- a/tools/eslint-config/eslint.config.cjs
+++ b/tools/eslint-config/eslint.config.cjs
@@ -1,0 +1,123 @@
+// eslint.config.js
+const js = require('@eslint/js')
+const typescript = require('@typescript-eslint/eslint-plugin')
+const typescriptParser = require('@typescript-eslint/parser')
+
+module.exports = [
+  {
+    files: ['**/*.{js,mjs,cjs,ts,tsx}'],
+    languageOptions: {
+      parser: typescriptParser,
+      parserOptions: {
+        ecmaVersion: 2021,
+        sourceType: 'module',
+      },
+      globals: {
+        // Node.js essentials
+        __dirname: 'readonly',
+        __filename: 'readonly',
+        process: 'readonly',
+        console: 'readonly',
+        Buffer: 'readonly',
+        global: 'readonly',
+        require: 'readonly',
+        module: 'readonly',
+        exports: 'readonly',
+        // Timers
+        setTimeout: 'readonly',
+        clearTimeout: 'readonly',
+        setInterval: 'readonly',
+        clearInterval: 'readonly',
+        setImmediate: 'readonly',
+        clearImmediate: 'readonly',
+      },
+    },
+    plugins: {
+      '@typescript-eslint': typescript,
+    },
+    rules: {
+      // Regole base di ESLint
+      ...js.configs.recommended.rules,
+
+      // Regole TypeScript raccomandate (solo quelle che non richiedono type info)
+      ...typescript.configs.recommended.rules,
+
+      // Configurazioni custom
+      'no-console': 'off',
+      'no-process-env': 'off',
+      '@typescript-eslint/no-unused-vars': ['error', { argsIgnorePattern: '^_' }],
+
+      // Code quality standards from guidelines
+      complexity: ['error', 10],
+      'max-depth': ['error', 4],
+      'max-lines-per-function': ['error', 50],
+      'max-params': ['error', 4],
+
+      // TypeScript-specific rules that enforce our guidelines
+      '@typescript-eslint/no-explicit-any': 'error',
+
+      // Functional programming preferences
+      'prefer-const': 'error',
+      'no-var': 'error',
+
+      // Prevent runtime errors that should be compile-time
+      'no-throw-literal': 'error',
+
+      // Disable no-undef for TypeScript files - TypeScript handles this better
+      'no-undef': 'off',
+    },
+  },
+  {
+    // Configurazione specifica per i file di test
+    files: ['**/*.test.{js,ts,tsx}', '**/*.spec.{js,ts,tsx}'],
+    languageOptions: {
+      globals: {
+        // Include tutte le globals di sopra
+        __dirname: 'readonly',
+        __filename: 'readonly',
+        process: 'readonly',
+        console: 'readonly',
+        Buffer: 'readonly',
+        global: 'readonly',
+        require: 'readonly',
+        module: 'readonly',
+        exports: 'readonly',
+        setTimeout: 'readonly',
+        clearTimeout: 'readonly',
+        setInterval: 'readonly',
+        clearInterval: 'readonly',
+        setImmediate: 'readonly',
+        clearImmediate: 'readonly',
+        // Globals per Vitest
+        describe: 'readonly',
+        it: 'readonly',
+        test: 'readonly',
+        expect: 'readonly',
+        beforeEach: 'readonly',
+        afterEach: 'readonly',
+        beforeAll: 'readonly',
+        afterAll: 'readonly',
+        vi: 'readonly',
+        // Browser globals for React component tests
+        window: 'readonly',
+        document: 'readonly',
+        HTMLElement: 'readonly',
+        HTMLButtonElement: 'readonly',
+        HTMLDivElement: 'readonly',
+        Element: 'readonly',
+      },
+    },
+    rules: {
+      'max-lines-per-function': 'off',
+    },
+  },
+  {
+    files: ['**/*.cjs', '**/scripts/**/*.js'],
+    rules: {
+      '@typescript-eslint/no-require-imports': 'off',
+    },
+  },
+  {
+    ignores: ['dist/', 'build/', 'node_modules/', '*.config.js', '*.config.ts', 'playwright/', 'test-results/'],
+  },
+]

--- a/tools/eslint-config/eslint.config.cjs
+++ b/tools/eslint-config/eslint.config.cjs
@@ -1,4 +1,3 @@
-// eslint.config.js
 const js = require('@eslint/js')
 const typescript = require('@typescript-eslint/eslint-plugin')
 const typescriptParser = require('@typescript-eslint/parser')
@@ -36,13 +35,13 @@ module.exports = [
       '@typescript-eslint': typescript,
     },
     rules: {
-      // Regole base di ESLint
+      // Base ESLint recommended rules
       ...js.configs.recommended.rules,
 
-      // Regole TypeScript raccomandate (solo quelle che non richiedono type info)
+      // TypeScript recommended rules (type-info-free only)
       ...typescript.configs.recommended.rules,
 
-      // Configurazioni custom
+      // Custom configuration
       'no-console': 'off',
       'no-process-env': 'off',
       '@typescript-eslint/no-unused-vars': ['error', { argsIgnorePattern: '^_' }],
@@ -63,16 +62,16 @@ module.exports = [
       // Prevent runtime errors that should be compile-time
       'no-throw-literal': 'error',
 
-      // Disable no-undef for TypeScript files - TypeScript handles this better
+      // Disable no-undef for TypeScript files — TypeScript handles this better
       'no-undef': 'off',
     },
   },
   {
-    // Configurazione specifica per i file di test
+    // Test-file specific configuration
     files: ['**/*.test.{js,ts,tsx}', '**/*.spec.{js,ts,tsx}'],
     languageOptions: {
       globals: {
-        // Include tutte le globals di sopra
+        // Inherit all base globals
         __dirname: 'readonly',
         __filename: 'readonly',
         process: 'readonly',
@@ -88,7 +87,7 @@ module.exports = [
         clearInterval: 'readonly',
         setImmediate: 'readonly',
         clearImmediate: 'readonly',
-        // Globals per Vitest
+        // Vitest globals
         describe: 'readonly',
         it: 'readonly',
         test: 'readonly',

--- a/tools/eslint-config/package.json
+++ b/tools/eslint-config/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "@gilberto/eslint-config",
+  "version": "0.0.0",
+  "private": true,
+  "description": "Shared ESLint flat-config for the gilberto monorepo",
+  "license": "MIT",
+  "main": "eslint.config.cjs",
+  "bin": {
+    "lint": "./bin/lint.sh",
+    "lint-fix": "./bin/lint-fix.sh",
+    "eslint": "./bin/eslint.sh"
+  },
+  "devDependencies": {
+    "eslint": "catalog:",
+    "@eslint/js": "catalog:",
+    "@typescript-eslint/eslint-plugin": "catalog:",
+    "@typescript-eslint/parser": "catalog:",
+    "globals": "catalog:"
+  }
+}

--- a/tools/eslint-config/package.json
+++ b/tools/eslint-config/package.json
@@ -10,6 +10,9 @@
     "lint-fix": "./bin/lint-fix.sh",
     "eslint": "./bin/eslint.sh"
   },
+  "scripts": {
+    "ts:check": "node -e \"require('./eslint.config.cjs'); console.log('ok')\""
+  },
   "devDependencies": {
     "eslint": "catalog:",
     "@eslint/js": "catalog:",

--- a/tools/markdownlint-config/.markdownlint.jsonc
+++ b/tools/markdownlint-config/.markdownlint.jsonc
@@ -11,9 +11,6 @@
   // MD013: Line length — disabled (prose wraps naturally)
   "MD013": false,
 
-  // MD024: Allow duplicate headings in different sections (sibling_only)
-  "MD024": { "siblings_only": true },
-
   // MD033: Allow inline HTML (needed for some KB content)
   "MD033": false,
 

--- a/tools/markdownlint-config/.markdownlint.jsonc
+++ b/tools/markdownlint-config/.markdownlint.jsonc
@@ -1,0 +1,43 @@
+{
+  // Base: all rules enabled
+  "default": true,
+
+  // MD003: Heading style — ATX only (# not underline)
+  "MD003": { "style": "atx" },
+
+  // MD004: Unordered list style — consistent within file
+  "MD004": { "style": "consistent" },
+
+  // MD013: Line length — disabled (prose wraps naturally)
+  "MD013": false,
+
+  // MD024: Allow duplicate headings in different sections (sibling_only)
+  "MD024": { "siblings_only": true },
+
+  // MD033: Allow inline HTML (needed for some KB content)
+  "MD033": false,
+
+  // MD036: Emphasis as heading — disabled (used intentionally in skill files)
+  "MD036": false,
+
+  // MD041: First line should be heading — disabled (YAML frontmatter files)
+  "MD041": false,
+
+  // MD026: Trailing punctuation in heading — disabled (KB uses "Step 1:", "Prerequisites:" etc.)
+  "MD026": false,
+
+  // MD060: Table column style — disabled (non-aligned tables are the norm in KB)
+  "MD060": false,
+
+  // MD001: Heading increment — disabled (KB guidelines intentionally skip levels, e.g. ## → ####)
+  "MD001": false,
+
+  // MD024: Duplicate headings — disabled (KB uses repeated section names across guideline files)
+  "MD024": false,
+
+  // MD025: Multiple top-level headings — disabled (some docs use multiple # headings for structure)
+  "MD025": false,
+
+  // MD046: Code block style — disabled (KB mixes fenced and indented intentionally)
+  "MD046": false
+}

--- a/tools/markdownlint-config/.markdownlintignore
+++ b/tools/markdownlint-config/.markdownlintignore
@@ -1,0 +1,9 @@
+node_modules/
+dist/
+build/
+coverage/
+.turbo/
+**/node_modules/
+**/.cache/
+CHANGELOG.md
+TODO.md

--- a/tools/markdownlint-config/README.md
+++ b/tools/markdownlint-config/README.md
@@ -1,0 +1,22 @@
+# @gilberto/markdownlint-config
+
+Shared markdownlint configuration for the pair monorepo.
+
+## Usage
+
+Scripts (via bin wrappers):
+
+```json
+"scripts": {
+  "mdlint:check": "markdownlint-check",
+  "mdlint:fix": "markdownlint-fix"
+}
+```
+
+The bin scripts auto-discover `.markdownlint.jsonc` and `.markdownlintignore` from this package.
+
+## Files
+
+- `.markdownlint.jsonc` — lint rules
+- `.markdownlintignore` — ignored patterns (node_modules, dist, CHANGELOG.md, etc.)
+- `bin/` — wrapper scripts (`markdownlint-check`, `markdownlint-fix`)

--- a/tools/markdownlint-config/README.md
+++ b/tools/markdownlint-config/README.md
@@ -1,6 +1,6 @@
 # @gilberto/markdownlint-config
 
-Shared markdownlint configuration for the pair monorepo.
+Shared markdownlint configuration for the gilberto monorepo.
 
 ## Usage
 

--- a/tools/markdownlint-config/bin/markdownlint-check.sh
+++ b/tools/markdownlint-config/bin/markdownlint-check.sh
@@ -1,0 +1,8 @@
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+MARKDOWNLINT_BIN="$SCRIPT_DIR/../node_modules/.bin/markdownlint"
+# Accept optional path args; default to **/*.md when none provided
+if [ $# -gt 0 ]; then
+  $MARKDOWNLINT_BIN --config "$SCRIPT_DIR/../.markdownlint.jsonc" --ignore-path "$SCRIPT_DIR/../.markdownlintignore" --dot "$@"
+else
+  $MARKDOWNLINT_BIN --config "$SCRIPT_DIR/../.markdownlint.jsonc" --ignore-path "$SCRIPT_DIR/../.markdownlintignore" --dot "**/*.md"
+fi

--- a/tools/markdownlint-config/bin/markdownlint-check.sh
+++ b/tools/markdownlint-config/bin/markdownlint-check.sh
@@ -1,8 +1,11 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 MARKDOWNLINT_BIN="$SCRIPT_DIR/../node_modules/.bin/markdownlint"
 # Accept optional path args; default to **/*.md when none provided
 if [ $# -gt 0 ]; then
-  $MARKDOWNLINT_BIN --config "$SCRIPT_DIR/../.markdownlint.jsonc" --ignore-path "$SCRIPT_DIR/../.markdownlintignore" --dot "$@"
+  "$MARKDOWNLINT_BIN" --config "$SCRIPT_DIR/../.markdownlint.jsonc" --ignore-path "$SCRIPT_DIR/../.markdownlintignore" --dot "$@"
 else
-  $MARKDOWNLINT_BIN --config "$SCRIPT_DIR/../.markdownlint.jsonc" --ignore-path "$SCRIPT_DIR/../.markdownlintignore" --dot "**/*.md"
+  "$MARKDOWNLINT_BIN" --config "$SCRIPT_DIR/../.markdownlint.jsonc" --ignore-path "$SCRIPT_DIR/../.markdownlintignore" --dot "**/*.md"
 fi

--- a/tools/markdownlint-config/bin/markdownlint-fix.sh
+++ b/tools/markdownlint-config/bin/markdownlint-fix.sh
@@ -1,0 +1,8 @@
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+MARKDOWNLINT_BIN="$SCRIPT_DIR/../node_modules/.bin/markdownlint"
+# Accept optional path args; default to **/*.md when none provided
+if [ $# -gt 0 ]; then
+  $MARKDOWNLINT_BIN --config "$SCRIPT_DIR/../.markdownlint.jsonc" --ignore-path "$SCRIPT_DIR/../.markdownlintignore" --fix --dot "$@"
+else
+  $MARKDOWNLINT_BIN --config "$SCRIPT_DIR/../.markdownlint.jsonc" --ignore-path "$SCRIPT_DIR/../.markdownlintignore" --fix --dot "**/*.md"
+fi

--- a/tools/markdownlint-config/bin/markdownlint-fix.sh
+++ b/tools/markdownlint-config/bin/markdownlint-fix.sh
@@ -1,8 +1,11 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 MARKDOWNLINT_BIN="$SCRIPT_DIR/../node_modules/.bin/markdownlint"
 # Accept optional path args; default to **/*.md when none provided
 if [ $# -gt 0 ]; then
-  $MARKDOWNLINT_BIN --config "$SCRIPT_DIR/../.markdownlint.jsonc" --ignore-path "$SCRIPT_DIR/../.markdownlintignore" --fix --dot "$@"
+  "$MARKDOWNLINT_BIN" --config "$SCRIPT_DIR/../.markdownlint.jsonc" --ignore-path "$SCRIPT_DIR/../.markdownlintignore" --fix --dot "$@"
 else
-  $MARKDOWNLINT_BIN --config "$SCRIPT_DIR/../.markdownlint.jsonc" --ignore-path "$SCRIPT_DIR/../.markdownlintignore" --fix --dot "**/*.md"
+  "$MARKDOWNLINT_BIN" --config "$SCRIPT_DIR/../.markdownlint.jsonc" --ignore-path "$SCRIPT_DIR/../.markdownlintignore" --fix --dot "**/*.md"
 fi

--- a/tools/markdownlint-config/package.json
+++ b/tools/markdownlint-config/package.json
@@ -9,6 +9,9 @@
     "markdownlint-check": "./bin/markdownlint-check.sh",
     "markdownlint-fix": "./bin/markdownlint-fix.sh"
   },
+  "scripts": {
+    "ts:check": "markdownlint --config ./.markdownlint.jsonc ./README.md"
+  },
   "devDependencies": {
     "markdownlint-cli": "catalog:"
   }

--- a/tools/markdownlint-config/package.json
+++ b/tools/markdownlint-config/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "@gilberto/markdownlint-config",
+  "version": "0.0.0",
+  "private": true,
+  "description": "Shared markdownlint configuration for the gilberto monorepo",
+  "license": "MIT",
+  "main": ".markdownlint.jsonc",
+  "bin": {
+    "markdownlint-check": "./bin/markdownlint-check.sh",
+    "markdownlint-fix": "./bin/markdownlint-fix.sh"
+  },
+  "devDependencies": {
+    "markdownlint-cli": "catalog:"
+  }
+}

--- a/tools/prettier-config/.prettierignore
+++ b/tools/prettier-config/.prettierignore
@@ -1,0 +1,9 @@
+build/
+node_modules/
+coverage/
+dist/
+.next/
+out/
+
+**/node_modules/
+**/.cache/

--- a/tools/prettier-config/.prettierrc.json
+++ b/tools/prettier-config/.prettierrc.json
@@ -1,0 +1,12 @@
+{
+  "semi": false,
+  "tabWidth": 2,
+  "printWidth": 100,
+  "singleQuote": true,
+  "trailingComma": "all",
+  "jsxSingleQuote": true,
+  "bracketSpacing": true,
+  "bracketSameLine": true,
+  "arrowParens": "avoid",
+  "endOfLine": "auto"
+}

--- a/tools/prettier-config/README.md
+++ b/tools/prettier-config/README.md
@@ -1,0 +1,37 @@
+# @gilberto/prettier-config
+
+Shared Prettier configuration for the gilberto monorepo. All packages use these rules by default unless they provide their own config.
+
+## Usage
+
+Add to your package's `package.json`:
+
+```json
+"prettier": "@gilberto/prettier-config"
+```
+
+Scripts (via bin wrappers):
+
+```json
+"scripts": {
+  "prettier:check": "prettier-check",
+  "prettier:fix": "prettier-fix"
+}
+```
+
+### Extending in a Package
+
+Create a `.prettierrc.js` in your package root:
+
+```js
+module.exports = {
+  ...require('@gilberto/prettier-config/.prettierrc.json'),
+  // package-specific overrides
+}
+```
+
+## Files
+
+- `.prettierrc.json` — formatting rules
+- `bin/` — wrapper scripts (`prettier-check`, `prettier-fix`)
+- `.prettierignore` — ignored patterns

--- a/tools/prettier-config/README.md
+++ b/tools/prettier-config/README.md
@@ -35,3 +35,7 @@ module.exports = {
 - `.prettierrc.json` — formatting rules
 - `bin/` — wrapper scripts (`prettier-check`, `prettier-fix`)
 - `.prettierignore` — ignored patterns
+
+## Scope
+
+The bin wrappers glob `{**/*,*}.{ts,tsx,js,jsx,json,html}` only. Markdown is handled by `@gilberto/markdownlint-config` (avoids the well-known Prettier ↔ markdownlint stylistic overlap). YAML files (`pnpm-workspace.yaml`, GitHub Actions, etc.) are intentionally out of scope of the bin wrappers — invoke `prettier --check '**/*.{yml,yaml}'` directly from a workspace if you need to gate them.

--- a/tools/prettier-config/bin/prettier-check.sh
+++ b/tools/prettier-config/bin/prettier-check.sh
@@ -1,0 +1,3 @@
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+PRETTIER_BIN="$SCRIPT_DIR/../node_modules/.bin/prettier"
+$PRETTIER_BIN --list-different "{**/*,*}.{ts,tsx,js,jsx,json,html}" --ignore-path $(dirname "$0")/../.prettierignore --log-level log  "$@"

--- a/tools/prettier-config/bin/prettier-check.sh
+++ b/tools/prettier-config/bin/prettier-check.sh
@@ -1,3 +1,6 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 PRETTIER_BIN="$SCRIPT_DIR/../node_modules/.bin/prettier"
-$PRETTIER_BIN --list-different "{**/*,*}.{ts,tsx,js,jsx,json,html}" --ignore-path $(dirname "$0")/../.prettierignore --log-level log  "$@"
+"$PRETTIER_BIN" --list-different "{**/*,*}.{ts,tsx,js,jsx,json,html}" --ignore-path "$SCRIPT_DIR/../.prettierignore" --log-level log "$@"

--- a/tools/prettier-config/bin/prettier-fix.sh
+++ b/tools/prettier-config/bin/prettier-fix.sh
@@ -1,0 +1,3 @@
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+PRETTIER_BIN="$SCRIPT_DIR/../node_modules/.bin/prettier"
+$PRETTIER_BIN "{**/*,*}.{ts,tsx,js,jsx,json,html}" --write --ignore-path $(dirname "$0")/../.prettierignore --log-level log  "$@"

--- a/tools/prettier-config/bin/prettier-fix.sh
+++ b/tools/prettier-config/bin/prettier-fix.sh
@@ -1,3 +1,6 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 PRETTIER_BIN="$SCRIPT_DIR/../node_modules/.bin/prettier"
-$PRETTIER_BIN "{**/*,*}.{ts,tsx,js,jsx,json,html}" --write --ignore-path $(dirname "$0")/../.prettierignore --log-level log  "$@"
+"$PRETTIER_BIN" "{**/*,*}.{ts,tsx,js,jsx,json,html}" --write --ignore-path "$SCRIPT_DIR/../.prettierignore" --log-level log "$@"

--- a/tools/prettier-config/package.json
+++ b/tools/prettier-config/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "@gilberto/prettier-config",
+  "version": "0.0.0",
+  "private": true,
+  "description": "Shared Prettier configuration for the gilberto monorepo",
+  "license": "MIT",
+  "main": ".prettierrc.json",
+  "bin": {
+    "prettier-check": "./bin/prettier-check.sh",
+    "prettier-fix": "./bin/prettier-fix.sh"
+  },
+  "keywords": ["prettier", "prettier-config"],
+  "devDependencies": {
+    "prettier": "catalog:"
+  }
+}

--- a/tools/prettier-config/package.json
+++ b/tools/prettier-config/package.json
@@ -10,6 +10,9 @@
     "prettier-fix": "./bin/prettier-fix.sh"
   },
   "keywords": ["prettier", "prettier-config"],
+  "scripts": {
+    "ts:check": "node -e \"JSON.parse(require('fs').readFileSync('./.prettierrc.json','utf8')); console.log('ok')\""
+  },
   "devDependencies": {
     "prettier": "catalog:"
   }

--- a/tools/ts-config/README.md
+++ b/tools/ts-config/README.md
@@ -1,0 +1,26 @@
+# @gilberto/ts-config
+
+Shared TypeScript configuration presets for the gilberto monorepo.
+
+## Presets
+
+| Preset | File | Use Case |
+|--------|------|----------|
+| Base | `base.json` | Common compiler options (strict mode, ESM, path resolution) |
+| Node | `node.json` | CLI and server packages (extends base + Node types) |
+| UI | `ui.json` | React/Next.js packages (extends base + JSX + DOM types) — lands with `apps/website/` (Phase 5, Initiative #5) |
+
+## Usage
+
+Extend a preset in your package's `tsconfig.json`:
+
+```json
+{
+  "extends": "@gilberto/ts-config/node.json",
+  "compilerOptions": {
+    "outDir": "dist",
+    "rootDir": "src"
+  },
+  "include": ["src"]
+}
+```

--- a/tools/ts-config/base.json
+++ b/tools/ts-config/base.json
@@ -1,0 +1,29 @@
+{
+  "$schema": "https://json.schemastore.org/tsconfig",
+  "compilerOptions": {
+    "baseUrl": ".",
+    "resolveJsonModule": true,
+    "allowSyntheticDefaultImports": true,
+    "strict": true,
+    "esModuleInterop": true,
+    "noImplicitAny": true,
+    "strictNullChecks": true,
+    "strictFunctionTypes": true,
+    "strictBindCallApply": true,
+    "strictPropertyInitialization": true,
+    "noImplicitThis": true,
+    "alwaysStrict": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "noImplicitReturns": true,
+    "noFallthroughCasesInSwitch": true,
+    "forceConsistentCasingInFileNames": true,
+    "useUnknownInCatchVariables": true,
+    "noPropertyAccessFromIndexSignature": true,
+    "exactOptionalPropertyTypes": true,
+    "noUncheckedIndexedAccess": true,
+    "noImplicitOverride": true,
+    "composite": true,
+    "declarationMap": false
+  }
+}

--- a/tools/ts-config/node.json
+++ b/tools/ts-config/node.json
@@ -1,0 +1,10 @@
+{
+  "$schema": "https://json.schemastore.org/tsconfig",
+  "extends": "./base.json",
+  "compilerOptions": {
+    "module": "NodeNext",
+    "target": "ES2022",
+    "moduleResolution": "nodenext",
+    "types": ["node"]
+  }
+}

--- a/tools/ts-config/package.json
+++ b/tools/ts-config/package.json
@@ -5,5 +5,8 @@
   "description": "Shared TypeScript configuration presets for the gilberto monorepo",
   "license": "MIT",
   "files": ["base.json", "node.json"],
-  "keywords": ["typescript", "tsconfig", "config"]
+  "keywords": ["typescript", "tsconfig", "config"],
+  "scripts": {
+    "ts:check": "node -e \"JSON.parse(require('fs').readFileSync('./base.json','utf8')); JSON.parse(require('fs').readFileSync('./node.json','utf8')); console.log('ok')\""
+  }
 }

--- a/tools/ts-config/package.json
+++ b/tools/ts-config/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "@gilberto/ts-config",
+  "version": "0.0.0",
+  "private": true,
+  "description": "Shared TypeScript configuration presets for the gilberto monorepo",
+  "license": "MIT",
+  "files": ["base.json", "node.json"],
+  "keywords": ["typescript", "tsconfig", "config"]
+}


### PR DESCRIPTION
Closes #32

## PR Information

**Story:** #32 — Setup shared tooling configs (eslint/prettier/markdownlint/ts-config)
**Parent Epic:** #7 — Monorepo & CI/CD baseline
**Type:** Chore (infrastructure / shared tooling)
**Priority:** P0
**Assignee:** @rucka
**Reviewers:** non-blocking per way-of-working §Pull Requests (single-contributor)
**Labels:** `infra`

## Summary

### What Changed

Adds four shared tooling packages at `tools/*` so every workspace inherits identical lint/format/typecheck conventions via `workspace:*` deps:

- `@gilberto/ts-config` — TS preset (`base.json` + `node.json`)
- `@gilberto/prettier-config` — Prettier preset + bin scripts
- `@gilberto/eslint-config` — ESLint 9 flat config + bin scripts
- `@gilberto/markdownlint-config` — markdownlint preset + bin scripts

Catalog block in `pnpm-workspace.yaml` pinned with shared versions (ESLint 9.34.0, @typescript-eslint 8.41.0, Prettier 3.6.2, markdownlint-cli 0.47.0, @eslint/js 9.34.0, globals 15.0.0).

### Why This Change

Without shared tooling, every workspace would re-declare lint/format/TS rules in `tools/eslint-config-prettier-markdownlint-tsconfig` quadruplicates. Centralizing these as `workspace:*` deps:

- guarantees identical conventions across `apps/`, `packages/`, `tools/`
- pins versions once via the pnpm catalog
- exposes bin shims (`lint`, `prettier-check`, `markdownlint-check`, `tsc -b`) consumers can wire directly into their `scripts`

Foundation for #33 (Husky hooks consume `lint`/`tsc`), #34 (quality-gate orchestrates these tools), #35 (CI runs the same commands), and every downstream workspace starting from #36 (apps/cli).

### Story Context

**User Story:** As a gilberto contributor, I want four shared tooling packages at `tools/*` so that every workspace inherits identical lint/format/typecheck conventions via `workspace:*` deps without duplicating configuration.

**Acceptance Criteria:** AC-1 through AC-7 (see issue #32). All verified via smoke matrix recorded in issue body §"Smoke Results (T-6)".

## Changes Made

### Implementation Details

- [x] **T-5** Catalog pinned for 7 shared tools in `pnpm-workspace.yaml` (typescript pin landed then dropped post-smoke pending #36)
- [x] **T-1** `@gilberto/ts-config` — `base.json` (strict + composite + noUncheckedIndexedAccess + exactOptionalPropertyTypes + …) + `node.json` (ES2022 + NodeNext)
- [x] **T-2** `@gilberto/prettier-config` — `.prettierrc.json` (no-semi, single-quote, print 100, trailing all, arrow-parens avoid) + bin scripts
- [x] **T-3** `@gilberto/eslint-config` — ESLint 9 flat config (complexity 10, max-depth 4, max-lines-per-function 50, max-params 4, no-explicit-any error, prefer-const, no-var, no-throw-literal) + bin scripts
- [x] **T-4** `@gilberto/markdownlint-config` — `.markdownlint.jsonc` with relaxations (MD003 atx, MD013/MD024/MD025/MD026/MD036/MD041/MD046 false) + bin scripts
- [x] **T-6** Smoke fixture (transient `tools/_sample-consumer/`) exercised the full matrix; lockfile resolved; fixture removed per story spec

### Files Changed

- **Added:**
  - `tools/ts-config/{package.json, base.json, node.json, README.md}`
  - `tools/prettier-config/{package.json, .prettierrc.json, .prettierignore, README.md, bin/{prettier-check,prettier-fix}.sh}`
  - `tools/eslint-config/{package.json, eslint.config.cjs, .eslintignore, README.md, bin/{lint,lint-fix,eslint}.sh}`
  - `tools/markdownlint-config/{package.json, .markdownlint.jsonc, .markdownlintignore, README.md, bin/{markdownlint-check,markdownlint-fix}.sh}`
- **Modified:** `pnpm-workspace.yaml` (catalog block extended), `pnpm-lock.yaml` (resolved)
- **Deleted:** none
- **Renamed:** none

### Database Changes

N/A — no database in scope.

### API Changes

N/A — no API surface in scope.

## Testing

### Test Coverage

- [x] **Unit Tests:** N/A — config packages, validated by self-parse + downstream smoke
- [x] **Integration Tests:** smoke fixture (transient `@gilberto/_sample-consumer`) exercising all four tools against a hello-world TS file
- [ ] **End-to-End Tests:** N/A
- [x] **Manual Testing:** clean + violation matrices on the smoke fixture

### Test Results

```text
Test Suite:      N/A (no automated test suite in scope of #32)
Smoke (clean):   lint ✅  prettier:check ✅  mdlint:check ✅  ts:check ✅
Smoke (break):   eslint→no-var ✅  prettier→fmt ✅  mdlint→MD007/030 ✅  tsc→TS2322 ✅
Quality Gate:    ✅ (placeholder — populated in #34)
Linting:         ✅ Clean (self-applied via sample fixture)
```

### Testing Strategy

- **Happy Path:** sample workspace consumes all four configs via `workspace:*` and `extends`; each tool exits 0 on clean code
- **Edge Cases:** intentional violation per tool; each tool exits 1 with the expected rule/error code
- **Error Handling:** N/A — config packages have no runtime branches
- **Performance:** N/A — install-time only; no runtime impact

## Quality Assurance

### Code Quality Checklist

- [x] Code follows established style guides (verbatim from `foomakers/pair`)
- [x] Each package has a `README.md` with usage and lifecycle notes
- [x] Bin scripts portable (`#!/usr/bin/env bash` style; SCRIPT_DIR pattern)
- [x] No debugging code or console logs
- [x] Conventional Commits used for every task (chore(infra) scope)

### Review Areas

- [x] **Business Logic:** verifies AC-1..AC-7 via smoke matrix
- [x] **Code Structure:** four packages under `tools/`, identical to pair's layout
- [x] **Error Handling:** N/A
- [x] **Performance:** N/A
- [x] **Security:** no external network calls, no user input handling
- [x] **Testing:** smoke matrix covers clean + violation per tool

## Documentation

### Documentation Updates

- [x] **README:** each of the four `tools/<name>-config/` packages ships a `README.md`
- [ ] **API Documentation:** N/A — no API
- [ ] **User Documentation:** N/A — internal tooling
- [x] **Technical Documentation:** [tech-stack.md §Shared Tooling](./.pair/adoption/tech/tech-stack.md) already lists the four packages; #32 makes them real

### Knowledge Sharing

- **Technical Decisions:** verbatim-from-pair adopted as the source-of-truth rule; deviations (no `eslint-config-prettier`, no `ui.json`, no `eslint.config.react.cjs`) explicitly documented
- **Best Practices:** wave-parallel execution via worktree subagents (way-of-working §Implementation Execution) — first PR to exercise this pattern

## Risk Assessment

### Technical Risks

| Risk                                                      | Impact | Probability | Mitigation                                                              |
| --------------------------------------------------------- | ------ | ----------- | ----------------------------------------------------------------------- |
| ESLint v9 flat-config breaking change in patch versions   | Medium | Low         | Pinned exact version in catalog (9.34.0); test before bumping           |
| `@gilberto/ts-config/base.json` too strict for consumers  | Medium | Medium      | Consumer can override locally; README documents how to relax            |
| Bin scripts non-portable across shells                    | Low    | Low         | POSIX-compliant; `SCRIPT_DIR` pattern (cross-shell safe)                |
| `cleanupUnusedCatalogs: true` strips `typescript` pin     | Low    | High        | Accepted — #36 re-pins with `apps/cli`; intent captured in `T-5` commit |

## Reviewer Guide

### Review Focus Areas

1. **Verbatim fidelity to pair:** verify each tool config matches `foomakers/pair/tools/<name>-config/` byte-for-byte (with documented namespace rename)
2. **Bin script portability:** confirm `SCRIPT_DIR` resolution works from a sample workspace (already exercised in T-6 smoke)
3. **Catalog cleanup:** confirm `typescript` pin removal is intentional (no consumer in scope of #32; #36 re-pins)

### Testing the Changes

```bash
git fetch origin && git checkout feat/32-shared-tooling-configs
pnpm install
# All four tools must resolve in node_modules/.pnpm and surface their bin shims.
# For an end-to-end check, re-create a throwaway consumer:
mkdir -p /tmp/sc/src && cd /tmp/sc
# ... (see issue body §Smoke Results for the full fixture content)
```

### Key Test Scenarios

1. **Clean code passes all four tools** — verified in smoke matrix (issue body §Smoke Results, clean state).
2. **Each tool catches its expected violation** — verified in smoke matrix (issue body §Smoke Results, violation state).
3. **Catalog resolution survives `pnpm install`** — only `typescript` (the unused one) is stripped post-smoke; all other pinned versions remain.

## Dependencies & Related Work

### Blocking Dependencies

- [x] **Prereq:** #31 (monorepo skeleton) — merged
- [ ] **Infrastructure:** none
- [ ] **Third-party:** none

### Related PRs

- **Follows:** #31 (Bootstrap monorepo skeleton)
- **Blocks:** #33 (Husky hooks consume `lint`/`tsc`), #34 (quality-gate orchestrates these tools), #35 (CI invokes them)
- **Related:** #36 (apps/cli) — first real consumer; will re-pin `typescript` catalog entry

### Follow-up Work

- [ ] **Technical Debt:** none introduced
- [x] **Future Enhancements:**
  - `@gilberto/ts-config/ui.json` lands with `apps/website/` (Initiative #5)
  - `@gilberto/eslint-config/eslint.config.react.cjs` lands with `apps/website/` (Initiative #5)
- [ ] **Monitoring:** N/A

## Pre-Submission Checklist

### Before Creating PR

- [x] All acceptance criteria implemented and tested (AC-1..AC-7)
- [x] Code follows team standards (verbatim from pair, conventional commits)
- [x] All smoke checks passing
- [x] Documentation updated (per-package READMEs)
- [x] Security considerations reviewed (N/A — config packages)
- [x] Performance impact assessed (N/A — install-time only)
- [x] Breaking changes documented (none)

### PR Description Complete

- [x] Clear summary of changes and business value
- [x] Testing strategy and results documented
- [x] Deployment considerations noted (N/A)
- [x] Review areas highlighted for reviewers
- [x] Related work and dependencies linked

### Ready for Review

- [x] Labels and metadata added
- [x] CI/CD pipeline status: pending first run (no CI yet — #35)
- [x] No merge conflicts with target branch
- [x] PR size appropriate for effective review (6 commits, ~30 files)

## Notes

- **Implementation pattern:** Wave 2 (T-1..T-4) executed in parallel via 4 worktree subagents per way-of-working §Implementation Execution. Each agent committed in its worktree; commits cherry-picked back into `feat/32-shared-tooling-configs` for a linear history.
- **`eslint-config-prettier` omitted:** pair's `eslint.config.cjs` doesn't use it; verbatim-from-pair rule wins.
- **`typescript` catalog pin dropped post-smoke:** no consumer in scope of #32; `#36` re-pins it when `apps/cli/` lands.